### PR TITLE
Location description is made optional.

### DIFF
--- a/app/elements/blocks/map-block/map-block.html
+++ b/app/elements/blocks/map-block/map-block.html
@@ -45,6 +45,7 @@
         --paper-content: {
           color: var(--primary-text-color);
         };
+        min-width: 320px;
         max-width: 400px;
         background: #FFFFFF;
       }
@@ -78,6 +79,12 @@
         display: none;
       }
 
+      @media (min-width: 601px) {
+        .card {
+          min-width: 400px;
+        }
+      }
+
       @media (min-width: 961px) {
         :host {
           padding: 100px 0;
@@ -106,10 +113,12 @@
           </div>
           <div class="paper-card-container">
             <div class="card-content list">
+              {% if location.description %}
               <paper-icon-item disabled>
                 <iron-icon icon="icons:feedback" item-icon></iron-icon>
                 <paper-item-body>{$ location.description $}</paper-item-body>
               </paper-icon-item>
+              {% endif %}
               <paper-icon-item disabled>
                 <iron-icon icon="icons:location" item-icon></iron-icon>
                 <paper-item-body two-line>


### PR DESCRIPTION
When there is no location, the width of the card becomes too small.

Header is always 400px for big screens, it becomes 320px min for small screens.

Here are the screenshots: 

![screen shot 2016-03-14 at 01 27 20](https://cloud.githubusercontent.com/assets/763339/13733057/826ff2ec-e985-11e5-81bd-e710ea63ecc4.png)

![screen shot 2016-03-14 at 01 31 00](https://cloud.githubusercontent.com/assets/763339/13733060/880662f4-e985-11e5-845b-be453aac8d65.png)


Fixes #40