### PR TITLE
Align map icons. 

### DIFF
--- a/app/elements/blocks/map-block/map-block.html
+++ b/app/elements/blocks/map-block/map-block.html
@@ -37,6 +37,10 @@
         @apply(--layout-around-justified);
       }
 
+      .card-content {
+        padding: 4px;
+      }
+
       .card {
         --paper-card-header-text: {
           color: #FFFFFF;

--- a/app/elements/blocks/map-block/map-block.html
+++ b/app/elements/blocks/map-block/map-block.html
@@ -38,7 +38,7 @@
       }
 
       .card-content {
-        padding: 4px;
+        padding-right: 8px; padding-left: 8px;
       }
 
       .card {


### PR DESCRIPTION
The default padding is 16px and too much. Decreased to 4px to align icons. 

Before | After 
-------- | --------
 ![screen shot 2016-03-14 at 01 38 10](https://cloud.githubusercontent.com/assets/763339/13733125/7a9e617e-e986-11e5-8e39-e31eca5e03a8.png) | ![screen shot 2016-03-14 at 01 43 19](https://cloud.githubusercontent.com/assets/763339/13733128/7fddb428-e986-11e5-941d-8dc8ce554833.png) 

