### PR TITLE
Fix header-content reads title & videoId from hoverboard.config.json

### DIFF
--- a/src/elements/header-content.html
+++ b/src/elements/header-content.html
@@ -200,7 +200,8 @@
         },
 
         _openVideo: function () {
-          HOVERBOARD.Elements.Template.openVideo('GDG DevFest Ukraine 2015', 'DfMnJAzOFng', true);
+          HOVERBOARD.Elements.Template.openVideo(this.app.data.pages.home.headerSettings.video.title,
+            this.app.data.pages.home.headerSettings.video.videoId, true);
           HOVERBOARD.Analytics.trackEvent('video', 'watch', 'GDG DevFest Ukraine 2015');
         },
 

--- a/src/elements/header-content.html
+++ b/src/elements/header-content.html
@@ -201,8 +201,8 @@
 
         _openVideo: function () {
           HOVERBOARD.Elements.Template.openVideo(this.app.data.pages.home.headerSettings.video.title,
-            this.app.data.pages.home.headerSettings.video.videoId, true);
-          HOVERBOARD.Analytics.trackEvent('video', 'watch', 'GDG DevFest Ukraine 2015');
+            this.app.data.pages.home.headerSettings.video.youtubeId, true);
+          HOVERBOARD.Analytics.trackEvent('video', 'watch', this.app.data.pages.home.headerSettings.video.title);
         },
 
         _scrollToTickets: function () {


### PR DESCRIPTION
Hi, video title & videoId in header-content is currently hard-coded instead of reading from hoverboard.config.json. This PR attempts to fix it.