### PR TITLE
Added GDG DevFest London 2016 to the list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ pull request, so we can include you in this list.
 | [GDG DevFest Lisbon 2016](https://devfestlisbon.firebaseapp.com) |
 | [GDG DevFest Sudbury 2016](https://devfest.gdgsudbury.ca) |
 | [GDG DevFest Hong Kong 2016](https://devfest.gdghk.org) |
+| [GDG DevFest London 2016](https://devfest-london-2016.firebaseapp.com/) |
 
 ### Roadmap :rocket:
 :x: Admin panel  


### PR DESCRIPTION
GDG DevFest London 2016 is using Hoverboard!