### PR TITLE
Update README.md: Add GDG Foumban website

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ pull request, so we can include you in this list.
 | [GDG DevFest Switzerland 2016](https://devfest.ch/)             | [GDG DevFest Toulouse 2016](https://devfesttoulouse.fr/)                    | [GDG Ohio DevFest](https://ohiodevfest.com/)                |
 | [GDG DevFest NYC 2016](https://devfestnyc.com/)                 | [GDG DevFest Los Angeles 2016](https://devfest.gdgla.org/)                  | [GDG DevFest West](https://devfest2016.gdgsv.com)           |
 | [GDG DevFest Florida 2016](https://devfestflorida.org)          | [GDG DevFest Madrid 2016](https://gdgmadrid.com)          |
+[GDG Foumban Website](https://gdgfoumban.org)  
 
 
 ### Roadmap :rocket:


### PR DESCRIPTION
GDG Foumban is using the template.