### PR TITLE
fix(docker): error during creation of images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ RUN npm i -g polymer-cli bower
 RUN useradd -m node 
 
 ADD . /app
+RUN chown -R node:node /app
 
 USER node
 WORKDIR /app 


### PR DESCRIPTION
Due to user node usage to run the polymer env, the bower command isn't able to download the dependencies causing an EACCESS error.

```
...
Removing intermediate container 2fe530dae3d6
Step 6/9 : WORKDIR /app
 ---> 0df61dc0a385
Removing intermediate container 3983f365c818
Step 7/9 : RUN bower install
 ---> Running in 6c0fe62a0bc2
bower app-layout#^0.10.0    not-cached https://github.com/PolymerElements/app-layout.git#^0.10.0
bower app-layout#^0.10.0       resolve https://github.com/PolymerElements/app-layout.git#^0.10.0
bower app-route#^0.9.0      not-cached https://github.com/PolymerElements/app-route.git#^0.9.0
bower app-route#^0.9.0         resolve https://github.com/PolymerElements/app-route.git#^0.9.0
bower app-localize-behavior#^0.10.0       not-cached https
...
bower                                                EACCES EACCES: permission denied, mkdir '/app/bower_components'

Stack trace:
Error: EACCES: permission denied, mkdir '/app/bower_components'
    at Error (native)

Console trace:
Error
    at StandardRenderer.error (/usr/local/lib/node_modules/bower/lib/renderers/StandardRenderer.js:81:37)
    at Logger.<anonymous> (/usr/local/lib/node_modules/bower/lib/bin/bower.js:110:26)
    at emitOne (events.js:96:13)
    at Logger.emit (events.js:188:7)
    at Logger.emit (/usr/local/lib/node_modules/bower/lib/node_modules/bower-logger/lib/Logger.js:29:39)
    at /usr/local/lib/node_modules/bower/lib/commands/index.js:48:20
    at _rejected (/usr/local/lib/node_modules/bower/lib/node_modules/q/q.js:844:24)
    at /usr/local/lib/node_modules/bower/lib/node_modules/q/q.js:870:30
    at Promise.when (/usr/local/lib/node_modules/bower/lib/node_modules/q/q.js:1122:31)
    at Promise.promise.promiseDispatch (/usr/local/lib/node_modules/bower/lib/node_modules/q/q.js:788:41)
System info:
Bower version: 1.8.0
Node version: 6.6.0
OS: Linux 4.9.8-moby x64
```

I just add a chmod command to allow node user to write in /app folder