### PR TITLE
fix(docker): allow access to serve from outside the container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,4 +13,4 @@ WORKDIR /app
 RUN bower install
 
 EXPOSE 8080
-CMD polymer serve
+CMD polymer serve --hostname 0.0.0.0


### PR DESCRIPTION
When  running serve command from the container, the loopback address was used and so the the serve operation was working only from inside the container and not from the guest system. Bind to 0.0.0.0 solves this problem -> https://github.com/Polymer/polymer-cli/issues/300

This and #232 allow to use the app directly from docker 😄 