### PR TITLE
chore(dep): remove global dependencies and replace it by dev dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,10 @@
 FROM node
 
-RUN npm i -g gulpjs/gulp#4.0
-RUN npm i -g bower
-
-RUN useradd -m node
-
 ADD . /app
 RUN chown -R node:node /app
 
 USER node
 WORKDIR /app
 
-RUN npm install
-RUN bower install
-
-EXPOSE 3000
-CMD gulp serve --hostname 0.0.0.0
+EXPOSE 3000 3001
+CMD npm install && npm run gulp -- serve

--- a/README.md
+++ b/README.md
@@ -37,38 +37,34 @@ from [GDG Lviv](http://lviv.gdg.org.ua/).
 
 If you don't want to bother with the dependencies, you can develop in the docker container.
 
-Build:
+Build the docker image :
 
     docker build -t hoverboard .
 
-and run:
-
-    docker run -it -v "$PWD":/app -p 3000:3000 hoverboard
+and execute the commands associated to the docker env in the following documentation
 
 :book: Read more in [docker docs](/docs/tutorials/docker.md).
-
-###### Prerequisites
-
-Install [gulp 4](https://github.com/gulpjs/gulp/tree/4.0):
-
-    npm i -g gulpjs/gulp#4.0
-
-and [Bower](https://bower.io/):
-
-    npm i -g bower
 
 :point_right: **[Fork](https://github.com/gdg-x/hoverboard/fork) this repository** and clone it locally.
 
 ##### Install dependencies
 
-    bower install && npm install
+    npm install
+    
+Or you can install with Docker container: 
+     
+    docker run -v "$PWD":/app hoverboard npm install 
 
 ##### Start the development server
 
 This command serves the app at `http://localhost:3000` and provides basic URL
 routing for the app:
 
-    gulp serve
+    npm run serve
+    
+Or you can serve Docker container:
+
+    docker run -v "$PWD":/app hoverboard
 
 :book: Read more in [setup docs](/docs/tutorials/set-up.md).
 
@@ -80,11 +76,11 @@ dependencies, and generates a service-worker.js file with code to pre-cache the
 dependencies based on the entrypoint and fragments specified in `polymer.json`.
 The minified files are output to the `build`.
 
-    gulp
+    npm run build
 
 Or you can build in Docker container:
 
-    docker run -v "$PWD":/app hoverboard gulp
+    docker run -v "$PWD":/app hoverboard npm run build
 
 :book: Read more in [deploy docs](/docs/tutorials/deploy.md).   
 

--- a/docs/tutorials/deploy.md
+++ b/docs/tutorials/deploy.md
@@ -35,7 +35,7 @@ The instructions below are based on the [Firebase quick start][Firebase quick st
 
 1.  Build
 
-        gulp
+        npm run build
 
 1.  Deploy
 

--- a/docs/tutorials/docker.md
+++ b/docs/tutorials/docker.md
@@ -1,18 +1,22 @@
 # Development in Docker container
 
-For simpler development setup you can use Docker.
+## For running the website directly from a container you can use docker : 
 
 1. Install docker https://docs.docker.com/ (Follow the installation instructions for your platform)
-2. Build the image `docker build -t hoverboard .`
+2. Build the image `docker build -t hoverboard .` and run the website with `docker run -it -p 3000:3000 -p 3001:3001 -v "$PWD":/app hoverboard`  
 
-Now you have prepared the local development environment!
+## For specific dev commands, you can run those from container : 
 
-Now you can run the project with local sources:
+Install all dependencies from docker command line :
 
-    docker run -it -v "$PWD":/app -p 3000:3000 hoverboard
+    docker run -it -v "$PWD":/app hoverboard npm install
+    
+Run the site from the container : 
 
-or build the production version:
+    docker run -it -p 3000:3000 -p 3001:3001 -v "$PWD":/app hoverboard npm run serve
 
-    docker run -v "$PWD":/app hoverboard gulp
+Build the production version:
+
+    docker run -it -v "$PWD":/app hoverboard npm run build
 
 For the explanation of the commands and their modifications please refer to https://docs.docker.com/engine/reference/run

--- a/docs/tutorials/set-up.md
+++ b/docs/tutorials/set-up.md
@@ -20,21 +20,6 @@ Or you may use [Docker container for development](docker.md)
         npm -v
         2.15.8
 
-1. Install [gulp 4](https://github.com/gulpjs/gulp/tree/4.0):
-      
-        npm i -g gulpjs/gulp#4.0 
-
-and Install [Bower](https://bower.io/):
-
-        npm install -g bower
-
-Note: the `-g` flag installs Gulp and Bower globally, so you may need to
-execute the script with `sudo` privileges. The reason they are installed
-globally is because some scripts in the Hoverboard expect `bower` to be 
-available from the command line.
-    
-
-
 1.  [Fork](https://github.com/gdg-x/hoverboard/fork) this repository
 
 1.  Clone it locally.
@@ -43,7 +28,7 @@ available from the command line.
 
 1.  Install the application dependencies.
 
-        bower install && npm install
+        npm install
 
 ## Directory structure
 
@@ -91,11 +76,11 @@ The Hoverboard is ready to be built and ran locally.
 
 1.  Serve the app locally.
 
-        gulp serve
+        npm run serve
 
 1.  Build the app.
 
-        gulp
+        npm run build
 
 
 ## Next steps

--- a/package.json
+++ b/package.json
@@ -3,10 +3,14 @@
   "version": "1.2.0",
   "description": "Conference website template",
   "scripts": {
+  	"gulp": "gulp",
+  	"bower": "bower",
     "build": "gulp",
+    "postinstall": "bower install",
     "serve": "gulp serve"
   },
   "devDependencies": {
+    "bower": "^1.8.0",
     "browser-sync": "^2.18.0",
     "connect-history-api-fallback": "^1.3.0",
     "css-slam": "^1.2.0",


### PR DESCRIPTION
Gulp and Bower shouldn't be installed globally, because we are all working on different project with different needs and don't want to have a new version of X or Y required for this project. To avoid this Prerequisites, we can install them as dev-dep in package.json and aliasing them in scripts. The result is event simpler than before (with pre install hook for example).

BTW, all the docker config was totally broken due to the use of npm and local dependencies... The installation (npm and bower install) was done during the build process but the shared volume override it and the node_modules, bower_components and other folders was missing during serve operation. So I fix the docker system and modify the documentation.

For now, you can install dependencies, serve and build. I will try to allow the firebase deployment operation later. By default, docker container do installation and serving if no parameter override the CMD (see the doc).

PS: The previous version without gulp was very simple, the PolymerCLI was quite good... 😢 