### PR TITLE
chore(ci): remove dependencies installation and useless step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ addons:
     packages:
     - g++-4.8
 install:
-- npm install -g bower
 - npm install
-- bower install
 script: echo "Deploying!"
 before_deploy: npm run build
 deploy:


### PR DESCRIPTION
Since the modification of the package.json and the full inclusion of bower, the travis-ci doesn't need to installed bower globally.
It's the same for the `bower install` step which is now triggered by the `npm install` step

Those modification has been tested by the GDGToulouse for our future DevFest site => https://travis-ci.org/GDGToulouse/site-devfest-toulouse-2017