### PR TITLE
fix(reload): error during reloading base on markdown and images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('serve', gulp.series(compileTemplate, () => {
   gulp.watch([
     'data/**/*.{markdown,md}',
     'images/**/*.{png,gif,jpg,svg}',
-  ]).on('change', reload);
+  ]).on('change', browserSync.reload);
 
   gulp.watch([
     'data/**/*.json',


### PR DESCRIPTION
While running gulp serve, when a file into `/data/**` or an image was changed, an error happened in the console and the server totally stop itself. 
This was because the `.on` method of `gulp.watch` doesn't give a callback but only the filename, so calling `done()` is first useless and end in error because the parameter was a string and not a function.