### PR TITLE
fix(serve): allow to update and serve markdown and images

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -123,6 +123,14 @@ function waitFor(stream) {
   });
 }
 
+function copyAndReload(file) {
+  const dest = prependPath(config.tempDirectory, file.substring(0, file.lastIndexOf('/')))		
+  
+  gulp.src(file).pipe(gulp.dest(dest));
+
+  browserSync.reload();
+}
+
 function reload(done) {
   browserSync.reload();
   done();
@@ -154,7 +162,7 @@ gulp.task('serve', gulp.series(compileTemplate, () => {
   gulp.watch([
     'data/**/*.{markdown,md}',
     'images/**/*.{png,gif,jpg,svg}',
-  ]).on('change', reload);
+  ]).on('change', copyAndReload);
 
   gulp.watch([
     'data/**/*.json',


### PR DESCRIPTION
Previously, an error occured when we modify a markdown or an image. This is fixed and a copy of files have been added and a reload of the webpage to see the modification in serve mode.