### PR TITLE
feat(blog): add locale and format for date presentation in config

### DIFF
--- a/data/hoverboard.config.json
+++ b/data/hoverboard.config.json
@@ -28,6 +28,10 @@
     "url": "https://gdg.us11.list-manage.com/subscribe/post?u=b7e853a79164ddfdbda3ed77b&amp;id=7993e39fbe",
     "name": "b_b7e853a79164ddfdbda3ed77b_7993e39fbe"
   },
+  "dateFormat": {
+    "locale": "en-US",
+    "blog": {"month": "short", "day": "numeric", "year": "numeric"}
+  },
   "hashtag": "dfua",
   "disqusShortName": "hoverboard-gdg-x",
   "tweetsSource": "/data/tweets.json",

--- a/src/pages/post-page.html
+++ b/src/pages/post-page.html
@@ -229,7 +229,7 @@
 
             this._post = this.posts[postIndex];
             this._updateHeaderSettings();
-            this.notifyPath('_post.date', new Date(this._post.posted).toDateString().slice(4));
+            this.notifyPath('_post.date', new Date(this._post.posted).toLocaleString('{$ dateFormat.locale $}', {$ dateFormat.blog | dump | safe $}));
 
             this._postUrl = '/data/posts/' + this._post.posted + '-' + this.postId + '.markdown';
             this.$.ajax.generateRequest();
@@ -249,7 +249,7 @@
               fontColor: '#fff',
               tabBarColor: '#fff',
               title: this._post.title,
-              subtitle: new Date(this._post.posted).toDateString().slice(4)
+              subtitle: new Date(this._post.posted).toLocaleString('{$ dateFormat.locale $}', {$ dateFormat.blog | dump | safe $})
             });
           }
         }


### PR DESCRIPTION
In order to let other GDG configure how date should be displayed, I've add in configuration the locale (default to en-US) and a parameter to be used in the `toLocaleString` on a Date Object (https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Date/toLocaleString).

Closes #258 and https://github.com/GDGToulouse/site-devfest-toulouse-2017/issues/45