### PR TITLE
feat(schedule): allow to publish speakers without the schedule & sessions

### DIFF
--- a/src/elements/app-data.html
+++ b/src/elements/app-data.html
@@ -166,10 +166,6 @@
         },
 
       _generateSchedule: function () {
-        if (!Object.keys(this._speakersRaw).length
-          || !Object.keys(this._sessionsRaw).length
-          || !Object.keys(this._scheduleRaw).length) return;
-
         var myWorker = new Worker('./scripts/helper/schedule-webworker.js');
 
         myWorker.postMessage({


### PR DESCRIPTION
In a standard workflow of a tech event, we are choosing featured speakers before creating the whole schedule. Our problem was the schedule / sessions, if empty in firebase, prevent the speakers part of the site to be initialised (due to this: https://github.com/gdg-x/hoverboard/blob/4b14a36f20c54e206be8a6c0f32715566c93dce5/src/elements/app-data.html#L169). In order to allow presentation of speakers without any information in schedule, we move the logic of 'not creating the schedule' in the web-worker if 'hasSpeakersAndSessionsAndSchedule'. In every case, the data are transferred back from the web-worker to the app-data component and propagated to every element.