### PR TITLE
feat(schedule): allow to publish speakers and sessions without the schedule

### DIFF
--- a/src/elements/speaker-details.html
+++ b/src/elements/speaker-details.html
@@ -84,8 +84,7 @@
                     characters="220"
                     break-last-word
                   ></truncate-marked-text>
-                  <a class="read-more" href$="/schedule/day[[session.day]]?sessionId=[[session.id]]" dialog-dismiss>{$ readMore $}</a>
-
+                  <a class="read-more" hidden$="{{!session.day}}" href$="/schedule/day[[session.day]]?sessionId=[[session.id]]" dialog-dismiss>{$ readMore $}</a>
                 </div>
               </div>
             </template>
@@ -170,9 +169,7 @@
             Polymer.IronDropdownScrollManager.removeScrollLock(this.$.scrollHeaderPanel);
             this._finishRenderClosed();
           }
-
         }
-
       });
 
     }());


### PR DESCRIPTION
After publication of the speakers, we can now thanks to this modification add speakers & sessions to firebase without schedule. This allow a simple communication without adding a fake schedule.

I've done a lot of modification the web-worker, so I decide to split it into smaller function(s). I found some variable was defined and never used (https://github.com/gdg-x/hoverboard/compare/master...davinkevin:speaker-with-sessions?expand=1#diff-882496eeebe036b245577926fa099862L11), so I would really like your opinion about this.

Let me know if you the behavior match your need. In our case, it's working in for the GDGToulouse (not in production, I'm waiting you to validate this to rebase for prod usage). 

😉 