### PR TITLE
feat(speakers): use id instead of position in firebase

### DIFF
--- a/scripts/helper/schedule-webworker.js
+++ b/scripts/helper/schedule-webworker.js
@@ -6,11 +6,15 @@ function clone(obj) {
   return JSON.parse(JSON.stringify(obj));
 }
 
+function findSpeakerById(id, speakerList) {
+  return speakerList.filter(function(s) {return s.id === +id;})[0];
+}
+
 function attachSessionAndSpeakersTogether(session, speakersRaw) {
   if (isDefined(session.speakers)) {
     for (var speakerIdx = 0; speakerIdx < session.speakers.length; speakerIdx++) {
       if (!isDefined(session.speakers[speakerIdx].id)) {
-        session.speakers[speakerIdx] = speakersRaw[session.speakers[speakerIdx]];
+        session.speakers[speakerIdx] = findSpeakerById(session.speakers[speakerIdx], speakersRaw);
         var tempSession = clone(session);
         delete tempSession.speakers;
         if (isDefined(session.speakers[speakerIdx])) {

--- a/src/pages/speakers-page.html
+++ b/src/pages/speakers-page.html
@@ -278,7 +278,7 @@
 
         _routePageChanged: function (speakerId) {
           if (speakerId && this.selected) {
-            var tempSpeaker = this.speakers[speakerId];
+            var tempSpeaker = this._findSpeakerById(speakerId);
             if (tempSpeaker) {
               window.requestAnimationFrame(function () {
                 this._selectedSpeaker = tempSpeaker;
@@ -286,6 +286,14 @@
               }.bind(this));
             }
           }
+        },
+
+        _findSpeakerById: function(id) {
+          if (!this.speakers.filter) {
+            return undefined;
+          }
+
+          return this.speakers.filter(function(s) {return s.id === +id;})[0];
         },
 
         _getCustomStyleValue: function (value) {


### PR DESCRIPTION
Some of the devfests use cfp.io which allow us to extract data in json to integrate it with the hoverboard project (with some `jq` transformations). 

In this system, the speakers and talks already have ids, so I made modification on the hoverboard project to handle speakers by id instead of position in array. This is much more simple to use and allow us to remove a speaker when we want without changing all the ids after him/her in the speakers list.

We have integrated it in DevfestToulouse and for now, seems to work well 😄 