### PR TITLE
feat(sessions): add information about the type of session

### DIFF
--- a/src/elements/session-details.html
+++ b/src/elements/session-details.html
@@ -121,7 +121,10 @@
                   / [[session.complexity]]
                 </span>
               </div>
-              <span class="meta">[[_concatArray(session.tags)]]</span>
+              <span class="meta">
+                  <span>[[_concatArray(session.tags)]]</span>
+                  <span hidden$="[[!session.type]]"> / [[session.type]]</span>
+              </span>
             </div>
           </div>
         </div>

--- a/src/elements/session-element.html
+++ b/src/elements/session-element.html
@@ -192,6 +192,11 @@
                 <span>[[_joinArray(session.tags)]]</span>
               </div>
 
+              <div hidden$="[[!session.type]]" layout horizontal center>
+                <iron-icon icon="info"></iron-icon>
+                <span>[[session.type]]</span>
+              </div>
+
               <div hidden$="[[!session.videoId]]" layout horizontal center>
                 <iron-icon icon="video"></iron-icon>
                 <span>Recording available</span>


### PR DESCRIPTION
In order to show the distinction between different kind of session (Conf, Codelab, Quicky, Tools in Action, Bof...), a key define in the Firebase data for each session is displayed in the interface

![image](https://user-images.githubusercontent.com/1970922/29900707-d08da5a0-8df3-11e7-9272-88b958b0fdf1.png)
![image](https://user-images.githubusercontent.com/1970922/29900716-da976a86-8df3-11e7-90dc-62ab89d46a95.png)

In this example, "conference" is shown next to the main tags of the session