### PR TITLE
fix(spacing): correction of spacing between words sessions

### DIFF
--- a/src/elements/session-details.html
+++ b/src/elements/session-details.html
@@ -75,6 +75,13 @@
         font-size: 12px;
         color: var(--secondary-text-color);
       }
+
+      .meta span:not(:last-of-type)::after {
+        margin-left: 5px;
+        margin-right: 5px;
+        content: "/";
+      }
+
     </style>
 
     <firebase-document
@@ -112,13 +119,21 @@
           <div class="main-info">
             <div class="info">
               <h1 class="main-title">[[session.title]]</h1>
-              <div class="meta highlight">[[session.dateReadable]] / [[session.startTime]] - [[session.endTime]] /
-                [[session.track.title]]
+              <div class="meta highlight">
+                <span>
+                  [[session.dateReadable]]
+                </span>
+                <span>
+                  [[session.startTime]] - [[session.endTime]]
+                </span>
+                <span>
+                  [[session.track.title]]
+                </span>
                 <span hidden$="[[!session.language]]">
-                  / [[session.language]]
+                  [[session.language]]
                 </span>
                 <span hidden$="[[!session.complexity]]">
-                  / [[session.complexity]]
+                  [[session.complexity]]
                 </span>
               </div>
               <span class="meta">[[_concatArray(session.tags)]]</span>

--- a/src/elements/session-element.html
+++ b/src/elements/session-element.html
@@ -71,6 +71,7 @@
 
       .session-meta li:not(:last-of-type)::after {
         margin-left: 5px;
+        margin-right: 5px;
         content: "/";
       }
 


### PR DESCRIPTION
Example from https://hoverboard-master.firebaseapp.com/schedule/day1?sessionId=129 : 
 
![image](https://user-images.githubusercontent.com/1970922/29901533-c728672a-8df8-11e7-8db4-67eab2200346.png)

![image](https://user-images.githubusercontent.com/1970922/29901554-cf64b97a-8df8-11e7-9851-8ae5105df3a7.png)

We choose to use CSS over text to fix this issue. 