### PR TITLE
Add featuredSessions database rule

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -18,6 +18,14 @@
         ".write": "auth.uid === $uid"
       }
     },
+    "featuredSessions": {
+      ".read": false,
+      ".write": false,
+      "$uid": {
+        ".read": "auth.uid === $uid",
+        ".write": "auth.uid === $uid"
+      }
+    },
     "speakers": {
       ".read": true,
       ".write": "root.child('users').child(auth.uid).child('rules').child('speakers').val() === true"


### PR DESCRIPTION
Without this rule, users will not be able to save their featured sessions in
Firebase.

Fixes #309

Signed-off-by: Dan Scott <denials@gmail.com>