### PR TITLE
Add Web Share API to share buttons

### DIFF
--- a/src/behaviors/share-behavior.html
+++ b/src/behaviors/share-behavior.html
@@ -16,6 +16,23 @@
         }
       },
 
+      nativeShare: function (e) {
+        if (navigator.share !== undefined) {
+          navigator.share({
+            url: location.href,
+            title: document.title,
+            text: 'Check out ' + document.title + ' at #{$ hashtag $}',
+          }).catch(function(err){
+            console.log('Web Share API failed', err);
+          });
+
+          // Prevent default action
+          // (do not popup share choices menu)
+          // as we already show native one
+          e.stopPropagation();
+        }
+      },
+
       share: function (e) {
         var type = e.currentTarget.getAttribute('share');
         var url = null;

--- a/src/elements/footer-block.html
+++ b/src/elements/footer-block.html
@@ -236,7 +236,7 @@
         </div>
 
         <paper-menu-button vertical-align="bottom" horizontal-align="left" share-menu>
-          <paper-icon-button icon="share" class="dropdown-trigger"></paper-icon-button>
+          <paper-icon-button icon="share" class="dropdown-trigger" on-tap="nativeShare"></paper-icon-button>
           <div class="dropdown-content">
             <paper-icon-item on-tap="share" share="gplus">
               <iron-icon icon="gplus" item-icon></iron-icon>

--- a/src/elements/session-details.html
+++ b/src/elements/session-details.html
@@ -150,7 +150,7 @@
 
         <div class="actions">
           <paper-menu-button class="share-menu" horizontal-align="left" vertical-align="bottom" share-menu>
-            <paper-button class="action dropdown-trigger">
+            <paper-button class="action dropdown-trigger" on-tap="nativeShare">
               <iron-icon icon="share"></iron-icon>
               {$ share $}
             </paper-button>


### PR DESCRIPTION
As Web Share API does not require origin trial since Chrome for Android v61, it can be introduced into the project without doubts.

This PR adds nativeShare action, which invokes native share dialog, to share behavior. This is how Web Share API works. As there are users who do not use Android/Chrome/etc, feature-detection is used to determine whether Web Share API is available. Please note, that it requires https to work.

If Web Share API is not available, it fallbacks to the default share behavior (invokes the dropdown with share options).

Closes #210 