### PR TITLE
Fix overlay sizes on small screens

### DIFF
--- a/src/pages/schedule-page.html
+++ b/src/pages/schedule-page.html
@@ -39,6 +39,10 @@
       schedule-day {
         margin-bottom: 64px;
       }
+
+      session-details {
+        min-height: 300px;
+      }
     </style>
 
     <app-route

--- a/src/pages/speakers-page.html
+++ b/src/pages/speakers-page.html
@@ -170,6 +170,10 @@
         width: 110px;
         height: 25px;
       }
+
+      speaker-details {
+        min-height: 300px;
+      }
     </style>
 
     <app-route route="{{route}}"


### PR DESCRIPTION
On smaller screens, the scrollbar of the overlay is hidden behind the `paper-toolbar` element. With this change, the overlay will be at least 300px high, so that you can at least scroll down in the content element.

Before: ![image](https://user-images.githubusercontent.com/326935/35555336-21fa8548-059f-11e8-981b-e7fff6fd84d7.png)
After: ![image](https://user-images.githubusercontent.com/326935/35555617-06a32cd6-05a0-11e8-99eb-09ef72d841c5.png)

Reproduction steps:

* set the browser window height to 350px
* go to a GDG website (e.g. https://devfest.ch/speakers/1/)
* you will be unable to scroll down in the overlay