### PR TITLE
Adding Valley DevFest 2017 to the who uses section

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,11 @@ pull request, so we can include you in this list.
 | [GDG DevFest NYC 2016](https://devfestnyc.com/)                 | [GDG DevFest Los Angeles 2016](https://devfest.gdgla.org/)                  | [GDG DevFest West](https://devfest2016.gdgsv.com)           |
 | [GDG DevFest Florida 2016](https://devfestflorida.org)          | [GDG DevFest Madrid 2016](https://gdgmadrid.com)                            | [GDG DevFest SBA 2016](https://devfest.gdgsba.org/)         |
 | [GDG Foumban Website](https://gdgfoumban.org)                   | [GDG DevFest Granada 2017](http://devfest.gdggranada.com/)                  | [GDG DevFest Taipei 2016](http://devfest.gdg-taipei.org/)   |
-| [2016 Valley DevFest](https://valleydevfest.com)                | [IWDC 2017 Fresno (WTM)](https://iwdc.wtmfresno.com/)                       | [ngVikings 2017](https://ngvikings.org)                     |
+| [2016 Valley DevFest](https://valleydevfest-620d6.firebaseapp.com/) | [IWDC 2017 Fresno (WTM)](https://wtm2017-146fd.firebaseapp.com/) | [ngVikings 2017](https://ngvikings.org)                     |
 | [Mobile Era 2017](https://mobileera.rocks)                      | [DevFest Nantes 2017](https://devfest.gdgnantes.com)                        | [GDG DevFest Hamburg 2017](https://hamburg.devfest.de/)     |
 | [GDG DevFest Baroda 2017](https://devfest.gdgbaroda.com/)       | [GDG DevFest Ahmedabad 2017](http://devfest.gdgahmedabad.com/)              | [GDG DevFest Sri Lanka 2017](https://devfest.gdgsrilanka.org/)     |
 | [GDG DevFest The Netherlands 2017](https://devfest.nl/)         | [GDG DevFest Manaus](https://devfestmanaus.com.br/)                         | [GDG DevFest Taipei 2017](https://devfest.gdg-taipei.org)   |
-|
+| [2017 Valley DevFest](https://valleydevfest.com)                |||
 
 ### Roadmap :rocket:
 :x: Admin panel    


### PR DESCRIPTION
Also modifying the IWDC 2017 and Valley DevFest 2016 links to point to the Firebase hosting directly because the domains are hosting more recent conference sites now.