### PR TITLE
Giving the full URL to twitter image meta tag (#402)

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
   <meta name="twitter:creator" content="@{$ organizer.twitter $}">
   <meta name="twitter:title" content="{$ title $}">
   <meta name="twitter:description" content="{$ description $}">
-  <meta name="twitter:image" content="/images/social-share.jpg">
+  <meta name="twitter:image" content="{$ url $}images/social-share.jpg">
 
   <link rel="dns-prefetch" href="https://www.google-analytics.com">
   <link rel="dns-prefetch" href="https://apis.google.com">

--- a/index.html
+++ b/index.html
@@ -42,7 +42,7 @@
   <!-- G+ sharing meta data -->
   <meta itemprop="name" content="{$ title $}">
   <meta itemprop="description" content="{$ description $}">
-  <meta itemprop="image" content="/images/social-share.jpg">
+  <meta itemprop="image" content="{$ url $}images/social-share.jpg">
   <meta itemprop="startDate" content="{$ startDate $}">
   <meta itemprop="endDate" content="{$ endDate $}">
 
@@ -53,7 +53,7 @@
   <meta property="og:url" content="{$ url $}">
   <meta property="og:description" content="{$ description $}">
   <meta property="og:type" content="Event">
-  <meta property="og:image" content="/images/social-share.jpg">
+  <meta property="og:image" content="{$ url $}images/social-share.jpg">
   <meta property="og:image:type" content="image/png" />
 
   <!-- Twitter meta data -->


### PR DESCRIPTION
Making sure twitter has the full path of the `social_share` image.
We applied this patch to [DevFest Pisa](https://devfest.gdgpisa.it/) website, it works fine.

![Imgur](https://i.imgur.com/YCKFwbZ.png)