### PR TITLE
Making sure `toastActions` exists before using it

### DIFF
--- a/scripts/service-worker-registration.js
+++ b/scripts/service-worker-registration.js
@@ -22,7 +22,7 @@
               installingWorker.onstatechange = () => {
                 switch (installingWorker.state) {
                   case 'installed':
-                    if (!navigator.serviceWorker.controller) {
+                    if (!navigator.serviceWorker.controller && toastActions) {
                       toastActions.showToast({
                         message: '{$ cachingComplete $}',
                       });


### PR DESCRIPTION
`toastActions` is sometimes `undefined` for some reason (seen it on Firefox).

Since a test on `toastActions` already exists on the same file (line 52), I figured we needed one here as well.

