### PR TITLE
feat(date): add support of locale in configuration for non en-US website

### DIFF
--- a/data/settings.json
+++ b/data/settings.json
@@ -12,6 +12,9 @@
     "themeColor": "#673AB7",
     "backgroundColor": "#673AB7"
   },
+  "dateFormat": {
+    "locale": "en-US"
+  },
   "hashtag": "DevFest17",
   "navigation": [
     {

--- a/src/mixins/utils-functions.html
+++ b/src/mixins/utils-functions.html
@@ -9,7 +9,7 @@
     }
 
     getDate(date) {
-      return new Date(date).toLocaleString('en-us', {
+      return new Date(date).toLocaleString('{$ dateFormat.locale $}', {
         month: 'short',
         day: 'numeric',
         year: 'numeric',

--- a/src/pages/post-page.html
+++ b/src/pages/post-page.html
@@ -157,19 +157,11 @@
         if (!this.postsList || !Object.keys(this.postsList).length) return;
         this.postInfo = this.postsList[this.postData.id];
         this.set('source', this.postsList[this.postData.id].source);
-        this.set('published', this._getDate(this.postsList[this.postData.id].published));
+        this.set('published', this.getDate(this.postsList[this.postData.id].published));
         const sortedPosts = this.transformToArray(this.postsList, 'id')
           .sort((a, b) => b.published.localeCompare(a.published));
         this.set('suggestedPosts', sortedPosts.filter((post) => post.id !== this.postData.id)
           .slice(0, 3));
-      }
-
-      _getDate(date) {
-        return new Date(date).toLocaleString('en-us', {
-          month: 'short',
-          day: 'numeric',
-          year: 'numeric',
-        });
       }
     }
 


### PR DESCRIPTION
Like proposed in v1 (8ec418b), a modification to support custom locale on the hoverboard project.

BTW, I've removed a duplicate function to format the date... 😉 

/cc @scraly https://github.com/GDGToulouse/site-devfest-toulouse-2018/issues/18