### PR TITLE
V2: Fix the Firebase config link

### DIFF
--- a/docs/tutorials/firebase.md
+++ b/docs/tutorials/firebase.md
@@ -17,7 +17,7 @@ In case to have Authentication and My Schedule features, you'll need a Firebase 
 	- YOUR_FIREBASE_DATABASE - The Firebase Realtime Database (for storing users' schedule)
 	- YOUR_API_KEY - Web API Key
 
-4. *Copy* all needed data, then paste it in `data/hoverboard.config.json`. This configuration looks like this:
+4. *Copy* all needed data, then paste it in `config/development.json` (and `config/production.json` if you use the same project in production). This configuration looks like this:
 
 	```
 	"firebase": {


### PR DESCRIPTION
Hoverboard v2 uses a different config path, but the documentation doesn't reflect it. This PR fixes the file path in the docs.