### PR TITLE
V2: Change the link to the main config file

### DIFF
--- a/docs/tutorials/configure-app.md
+++ b/docs/tutorials/configure-app.md
@@ -1,6 +1,6 @@
 # Configure
 
-The most important file of configuration is `data/hoverboard.config.json`
+The most important file of configuration is `data/settings.json`
 which looks like:
 
 ```


### PR DESCRIPTION
The main configuration file is listed as `data/hoverboard.config.json`, but it's been changed to `data/settings.json` in V2.

P.S. Sorry for all the separate PRs, I hope it's fine! I'm just editing them as I go through the docs.