### PR TITLE
V2: Add a CLI line for Firebase data import to the docs

### DIFF
--- a/docs/tutorials/firebase.md
+++ b/docs/tutorials/firebase.md
@@ -31,7 +31,11 @@ In case to have Authentication and My Schedule features, you'll need a Firebase 
 	}
 	```
 	
-5. Import data to the Firebase Database. You can use [default-firebase-data.json](https://github.com/gdg-x/hoverboard/blob/master/docs/default-firebase-data.json) schema and then update it with your information.
+5. Import data to the Firebase Database. You can use [default-firebase-data.json](https://github.com/gdg-x/hoverboard/blob/master/docs/default-firebase-data.json) schema and then update it with your information:
+
+  ```
+  firebase database:set / docs/default-firabase-data.json
+  ```
 
 6. Whoa! You've set up Firebase into your app.
 


### PR DESCRIPTION
Add a helpful example of importing the entire `default-firebase-data.json` into a newly created Firebase project. Not super useful, but could save someone a few minutes of digging through the Firebase CLI documentation or the Web UI. :)