### PR TITLE
fix(database): install firebase tools to allow yarn firestore:init

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "eslint-plugin-html": "^4.0.1",
     "eslint-plugin-polymer": "^0.1.0",
     "firebase-admin": "^5.12.1",
+    "firebase-tools": "^3.19.3",
     "gulp": "^4.0.0",
     "gulp-cli": "^2.0.0",
     "gulp-eslint": "^4.0.0",


### PR DESCRIPTION
The actual command is using the `firebase` cli, so if we don't have it installed globally (like me and a lots of people), we need to have a dependency for it in the package.json.