### PR TITLE
Fix gallery-block call to action link

### DIFF
--- a/src/elements/gallery-block.html
+++ b/src/elements/gallery-block.html
@@ -141,7 +141,7 @@
           <h2>{$ galleryBlock.title $}</h2>
           <p>{$ galleryBlock.description $}</p>
         </div>
-        <a href="{$ galleryBlock.callToAction.url $}" target="_blank" rel="noopener noreferrer">
+        <a href="{$ galleryBlock.callToAction.link $}" target="_blank" rel="noopener noreferrer">
           <paper-button>{$ galleryBlock.callToAction.label $}</paper-button>
         </a>
       </div>


### PR DESCRIPTION
Changed galleryBlock.callToAction.url to galleryBlock.callToAction.link

https://github.com/gdg-x/hoverboard/blob/master/data/resources.json#L206
As it can be seen above, the item is called `link` in `resources.json` file.