### PR TITLE
fix(docs): mailchimp function configuration example

### DIFF
--- a/docs/tutorials/mailchimp-autosubscribe.md
+++ b/docs/tutorials/mailchimp-autosubscribe.md
@@ -3,9 +3,9 @@ This tutorial describes how to enable Mailchimp autosubscription feature. So tha
 ## Setup
 1.  Set the firebase config variables for Mailchimp configuration (you can find API data on your account)
     ```console
-      firebase functions:config:set mailchimpConfig.dc="<DATA_CENTER_FOR_YOUR_ACCOUNT>"
-                                    mailchimpConfig.listid="<LIST_ID_YOU_WANT_SUBSCRIBE_TO>"
-                                    mailchimpConfig.apikey="<YOUR_API_KEY>"
+      firebase functions:config:set mailchimp.dc="<DATA_CENTER_FOR_YOUR_ACCOUNT>"
+                                    mailchimp.listid="<LIST_ID_YOU_WANT_SUBSCRIBE_TO>"
+                                    mailchimp.apikey="<YOUR_API_KEY>"
     ```
 1.  Deploy Firebase functions. You can find specific Mailchimp autosubscibe function [here](https://github.com/gdg-x/hoverboard/blob/master/functions/src/mailchimp-subscribe.js)
     ```console


### PR DESCRIPTION
function configuration variables can't have upper case letters, fix #501 