### PR TITLE
Anonymizing ips for GDPR compliance

### DIFF
--- a/src/elements/hoverboard-analytics.html
+++ b/src/elements/hoverboard-analytics.html
@@ -28,6 +28,7 @@
       ga('require', 'urlChangeTracker');
       ga('require', 'pageVisibilityTracker');
 
+      ga('set', 'anonymizeIp', true);
       ga('send', 'pageview');
 
       let updateOnlineStatus = (event) => {


### PR DESCRIPTION
Anonymizing the IPs is one of the requirements of GDPR. As I do not see this having any negative impact, I suggest we add this as default setting in hoverboard