### PR TITLE
Adding possibility to add short descriptions for sessions.

### DIFF
--- a/data/settings.json
+++ b/data/settings.json
@@ -17,6 +17,7 @@
   },
   "hashtag": "DevFest17",
   "disabledSchedule": false,
+  "showSessionShortAbstract": true,
   "navigation": [
     {
       "route": "home",

--- a/docs/default-firebase-data.json
+++ b/docs/default-firebase-data.json
@@ -522,6 +522,7 @@
     "120" : {
       "complexity" : "Beginner",
       "description" : "\"Remember back when AJAX completely changed what was possible in the desktop web? Progressive web apps are that same fundamental shift for the mobile web.\" said Rahul Row-Chowdhury (Google’s product lead for chrome and the web platform) on stage at Google I/O 2016. - Progressive web apps use service workers, app shell, push notifications, RAIL and other capabilities to deliver an app-like user experience.",
+      "shortDescription": "Progressive web apps are are fundamental shift for the mobile web, learn what they are and how they are made. Click to see more...",
       "language" : "English",
       "presentation" : "https://speakerdeck.com/gdglviv/jakub-skvara-progressive-web-apps-prepare-your-web-for-2017",
       "speakers" : [ "jana_moudra" ],

--- a/src/elements/session-element.html
+++ b/src/elements/session-element.html
@@ -80,6 +80,10 @@
         line-height: 1.2;
       }
 
+      .session-description {
+        margin-top: 8px;
+      }
+
       .session-meta {
         margin: 0;
         padding: 0;
@@ -149,6 +153,7 @@
       <div class="session-header" layout horizontal justified>
         <div flex>
           <h3 class="session-title">[[session.title]]</h3>
+          <div class="session-description" hidden$="[[!session.shortDescription]]">[[session.shortDescription]]</div>
         </div>
         <span class="language">[[slice(session.language, 2)]]</span>
       </div>

--- a/src/elements/session-element.html
+++ b/src/elements/session-element.html
@@ -153,7 +153,7 @@
       <div class="session-header" layout horizontal justified>
         <div flex>
           <h3 class="session-title">[[session.title]]</h3>
-          <div class="session-description" hidden$="[[!session.shortDescription]]">[[session.shortDescription]]</div>
+          <div class="session-description" hidden$="[[_hideSessionAbstract(session.shortDescription)]]">[[session.shortDescription]]</div>
         </div>
         <span class="language">[[slice(session.language, 2)]]</span>
       </div>
@@ -231,6 +231,10 @@
             type: String,
             computed: '_isFeatured(featuredSessions, session.id)',
           },
+          showSessionShortAbstract: {
+            type: Boolean,
+            value: () => JSON.parse('{$ showSessionShortAbstract $}'),
+          },
         };
       }
 
@@ -248,6 +252,10 @@
 
       _getEnding(number) {
         return number > 1 ? 's' : '';
+      }
+
+      _hideSessionAbstract(sesionAbstract) {
+        return !this.showSessionShortAbstract || !sesionAbstract;
       }
 
       _getFeaturedSessionIcon(featuredSessions, sessionId) {


### PR DESCRIPTION
This is especially useful for events with only few tracks. In such case users do not think of clicking any session to see the details.

![session-description](https://user-images.githubusercontent.com/15854950/47994056-efd51d80-e0f9-11e8-8c01-b5501b807a1e.png)
