### PR TITLE
Added -y parameter to "firebase firestore:delete" to fix the import

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "predeploy": "cd ./functions && npm i",
     "deploy": "gulp deploy",
     "deploy:prod": "cross-env BUILD_ENV=production gulp deploy",
-    "firestore:init": "firebase firestore:delete -r --all-collections && firebase functions:config:set schedule.enabled=true && firebase deploy --except hosting && babel-node ./internals/import-default-data",
+    "firestore:init": "firebase firestore:delete -r --all-collections -y && firebase functions:config:set schedule.enabled=true && firebase deploy --except hosting && babel-node ./internals/import-default-data",
     "firestore:copy": "babel-node ./internals/firestore-copy-data",
     "postinstall": "bower install",
     "serve": "gulp serve",


### PR DESCRIPTION
Without this parameter the command `yarn firestore:init` fails with `Error: Missing required options (confirm) while running in non-interactive mode: - confirm` error