### PR TITLE
Remove SW check

### DIFF
--- a/scripts/service-worker-registration.js
+++ b/scripts/service-worker-registration.js
@@ -1,44 +1,37 @@
 (function () {
   'use strict';
 
-  // Ensure we only attempt to register the SW once.
-  let isAlreadyRegistered = false;
-
   const URL = 'service-worker.js';
   const SCOPE = Polymer.rootPath;
 
   const register = () => {
-    if (!isAlreadyRegistered) {
-      isAlreadyRegistered = true;
+    if ('serviceWorker' in navigator) {
+      navigator.serviceWorker.register(URL, {
+        scope: SCOPE,
+      })
+        .then((registration) => {
+          registration.onupdatefound = () => {
+            const installingWorker = registration.installing;
 
-      if ('serviceWorker' in navigator) {
-        navigator.serviceWorker.register(URL, {
-          scope: SCOPE,
-        })
-          .then((registration) => {
-            registration.onupdatefound = () => {
-              const installingWorker = registration.installing;
-
-              installingWorker.onstatechange = () => {
-                switch (installingWorker.state) {
-                  case 'installed':
-                    if (!navigator.serviceWorker.controller && toastActions) {
-                      toastActions.showToast({
-                        message: '{$ cachingComplete $}',
-                      });
-                    }
-                    break;
-                  case 'redundant':
-                    throw Error('The installing service worker became redundant.');
-                }
-              };
+            installingWorker.onstatechange = () => {
+              switch (installingWorker.state) {
+                case 'installed':
+                  if (!navigator.serviceWorker.controller && toastActions) {
+                    toastActions.showToast({
+                      message: '{$ cachingComplete $}',
+                    });
+                  }
+                  break;
+                case 'redundant':
+                  throw Error('The installing service worker became redundant.');
+              }
             };
-          })
-          .catch((e) => {
-            // eslint-disable-next-line no-console
-            console.error('Service worker registration failed:', e);
-          });
-      }
+          };
+        })
+        .catch((e) => {
+          // eslint-disable-next-line no-console
+          console.error('Service worker registration failed:', e);
+        });
     }
   };
 


### PR DESCRIPTION
Checking to see if a SW is already registered is unnecessary.

> You can call register() every time a page loads without concern; the browser will figure out if the service worker is already registered or not and handle it accordingly.

https://developers.google.com/web/fundamentals/primers/service-workers/