### PR TITLE
Remove Firestore timestmapInSnapshots flag

### DIFF
--- a/index.html
+++ b/index.html
@@ -116,8 +116,6 @@
           messagingSenderId: '{$ firebase.messagingSenderId $}',
         });
 
-        const firestore = firebase.firestore();
-        firestore.settings({ timestampsInSnapshots: true });
         firebase.firestore()
           .enablePersistence({ experimentalTabSynchronization: true })
           .catch(() => {


### PR DESCRIPTION
Fixes:

> @firebase/firestore: Firestore (5.11.1): 
  The timestampsInSnapshots setting now defaults to true and you no
  longer need to explicitly set it. In a future release, the setting
  will be removed entirely and so it is recommended that you remove it
  from your firestore.settings() call now.