### PR TITLE
Use venue address for Google Maps directions link

### DIFF
--- a/src/elements/map-block.html
+++ b/src/elements/map-block.html
@@ -79,7 +79,7 @@
         <div class="bottom-info" layout horizontal justified center>
           <span class="address">{$ location.address $}</span>
           <a
-            href="https://www.google.com/maps/dir/?api=1&destination={$ location.pointer.latitude $},{$ location.pointer.longitude $}"
+            href="https://www.google.com/maps/dir/?api=1&destination={$ location.address $}"
             target="_blank"
             rel="noopener noreferrer"
           >


### PR DESCRIPTION
Google Maps seems to produce better directions when it's to a specific address instead of coordinates.