### PR TITLE
Load hoverboard-app as an element

### DIFF
--- a/index.html
+++ b/index.html
@@ -93,13 +93,6 @@
           })));
     }
 
-    function loadHoverboardApp() {
-      requestAnimationFrame(() => {
-        const app = document.createElement('hoverboard-app');
-        document.body.appendChild(app);
-      });
-    }
-
     loadFirebaseModules([
       'firebase-app',
       'firebase-firestore',
@@ -123,9 +116,7 @@
               });
           // eslint-disable-next-line no-console
           console.log('Firebase App is ready!');
-        })
-        .then(() => loadHoverboardApp());
-
+        });
   </script>
 
   <script src="bower_components/webcomponentsjs/webcomponents-loader.js"></script>
@@ -171,7 +162,7 @@
 
 <body>
 
-<!--<hoverboard-app unresolved>{$ title $}</hoverboard-app>-->
+  <hoverboard-app unresolved>{$ title $}</hoverboard-app>
 
 <noscript>
   Please enable JavaScript to view this website.


### PR DESCRIPTION
Some Firefox users have been getting blank pages caused by `loadHoverboardApp` getting called before `document.body` being ready and throwing an error.