### PR TITLE
Always show session description

### DIFF
--- a/data/settings.json
+++ b/data/settings.json
@@ -17,7 +17,6 @@
   },
   "hashtag": "DevFest17",
   "disabledSchedule": false,
-  "showSessionShortAbstract": true,
   "navigation": [
     {
       "route": "home",

--- a/docs/default-firebase-data.json
+++ b/docs/default-firebase-data.json
@@ -522,7 +522,6 @@
     "120" : {
       "complexity" : "Beginner",
       "description" : "\"Remember back when AJAX completely changed what was possible in the desktop web? Progressive web apps are that same fundamental shift for the mobile web.\" said Rahul Row-Chowdhury (Google’s product lead for chrome and the web platform) on stage at Google I/O 2016. - Progressive web apps use service workers, app shell, push notifications, RAIL and other capabilities to deliver an app-like user experience.",
-      "shortDescription": "Progressive web apps are are fundamental shift for the mobile web, learn what they are and how they are made. Click to see more...",
       "language" : "English",
       "presentation" : "https://speakerdeck.com/gdglviv/jakub-skvara-progressive-web-apps-prepare-your-web-for-2017",
       "speakers" : [ "jana_moudra" ],

--- a/src/elements/session-element.html
+++ b/src/elements/session-element.html
@@ -6,6 +6,7 @@
 
 <link rel="import" href="../mixins/utils-functions.html">
 <link rel="import" href="../mixins/redux-mixin.html">
+<link rel="import" href="./text-truncate.html">
 <link rel="import" href="./shared-styles.html">
 
 <dom-module id="session-element">
@@ -150,7 +151,9 @@
       <div class="session-header" layout horizontal justified>
         <div flex>
           <h3 class="session-title">[[session.title]]</h3>
-          <div class="session-description" hidden$="[[_hideSessionAbstract(session.shortDescription)]]">[[session.shortDescription]]</div>
+          <text-truncate lines="3">
+            <div class="session-description">[[session.description]]</div>
+          </text-truncate>
         </div>
         <span class="language">[[slice(session.language, 2)]]</span>
       </div>
@@ -229,10 +232,6 @@
             type: String,
             computed: '_isFeatured(featuredSessions, session.id)',
           },
-          showSessionShortAbstract: {
-            type: Boolean,
-            value: () => JSON.parse('{$ showSessionShortAbstract $}'),
-          },
         };
       }
 
@@ -243,10 +242,6 @@
 
       _getEnding(number) {
         return number > 1 ? 's' : '';
-      }
-
-      _hideSessionAbstract(sesionAbstract) {
-        return !this.showSessionShortAbstract || !sesionAbstract;
       }
 
       _getFeaturedSessionIcon(featuredSessions, sessionId) {


### PR DESCRIPTION
Removes the complexity of `shortDescription` and always use truncated version.

Before:
![Screenshot from 2019-08-18 13-11-53](https://user-images.githubusercontent.com/3341/63228539-fbda2980-c1b9-11e9-9f2c-442def24dcc3.png)

After:
![Screenshot from 2019-08-18 13-10-40](https://user-images.githubusercontent.com/3341/63228536-f7ae0c00-c1b9-11e9-8995-9f95a052aa82.png)
