### PR TITLE
Fixing Hero Block occupying only a fraction of the screen.

### DIFF
--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -95,7 +95,7 @@
 
       @media (min-height: 500px) {
         hero-block {
-          height: calc(100% + 57px);
+          height: calc(100vh + 57px);
           max-height: calc(100vh + 1px);
         }
 
@@ -114,7 +114,7 @@
 
       @media (min-width: 812px) {
         hero-block {
-          height: calc(100% + 65px);
+          height: calc(100vh + 65px);
         }
 
         .hero-logo {


### PR DESCRIPTION
Fixes #649

Before:
<img width="1792" alt="Screenshot 2019-09-03 at 00 03 47" src="https://user-images.githubusercontent.com/3001957/64134535-04984580-cddf-11e9-8e35-d01ac510904c.png">

After:
<img width="1792" alt="Screenshot 2019-09-03 at 00 07 25" src="https://user-images.githubusercontent.com/3001957/64134542-14178e80-cddf-11e9-9c26-2a2237be24fd.png">
