### PR TITLE
Update Tag Design to match Material Chips

### DIFF
--- a/src/elements/filter-menu.html
+++ b/src/elements/filter-menu.html
@@ -124,6 +124,10 @@
             <h3 class="filter-title">[[filter.title]]</h3>
             <template is="dom-repeat" items="[[filter.items]]" as="item">
               <div
+                layout
+                horizontal
+                inline
+                center
                 class="tag"
                 style$="--color: [[getVariableColor(item, 'primary-text-color')]]"
                 filter-key$="[[filter.key]]"

--- a/src/elements/shared-styles.html
+++ b/src/elements/shared-styles.html
@@ -217,10 +217,13 @@
       }
 
       .tag {
-        margin-right: 2px;
-        padding: 2px 4px;
+        height: 32px;
+        padding: 8px 12px;
         font-size: 12px;
+        color: currentColor;
+        background: white;
         border: 1px solid currentColor;
+        border-radius: 32px;
       }
 
       @media (min-width: 640px) {


### PR DESCRIPTION
I've updated the layout of tags to match the one of outlined Chips.
For the selected state, I'm keeping the previous behavior of inverting the colors. 

Filter:
<img width="288" alt="Screenshot 2019-09-03 at 01 18 12" src="https://user-images.githubusercontent.com/3001957/64135465-167ee600-cde9-11e9-99a2-aefb50aa1588.png">

Selected Tags:
<img width="415" alt="Screenshot 2019-09-03 at 01 18 21" src="https://user-images.githubusercontent.com/3001957/64135466-1b439a00-cde9-11e9-9bf1-1ce7efb30e7e.png">

Tag in Session Detail:
<img width="780" alt="Screenshot 2019-09-03 at 01 18 32" src="https://user-images.githubusercontent.com/3001957/64135469-20084e00-cde9-11e9-8a59-4515ba2c3210.png">

Tag in Schedule:
<img width="1278" alt="Screenshot 2019-09-03 at 01 18 46" src="https://user-images.githubusercontent.com/3001957/64135474-24cd0200-cde9-11e9-9eef-e2a303001972.png">

Fixes #628