### PR TITLE
Add support for using local Markdown files for blogposts

### DIFF
--- a/data/posts/2017-02-12-c4p.md
+++ b/data/posts/2017-02-12-c4p.md
@@ -1,0 +1,43 @@
+GDG DevFest Ukraine was announced, for the sixth year in a row, the conference will bring together 900 developers, managers and entrepreneurs on **October 13-14** to Lviv. 
+
+This year our team is doing big advancement in the content, we're building an extra stage to accommodate more visitors and provide three fully independent tracks on Android, Web and Google Cloud topics. 
+
+Our focus is the content. **We’re looking for speakers like you**, who are ready to rock the stage and deliver the best talk or workshop in the field. "I've been to conferences all over the world and what you've created in Lviv is world class. It's easily first league of conferences." - Piotr Tuszynski, DevFest '16 Keynote Speaker 
+
+<div layout horizontal center-justified> <a href="http://bit.ly/df17-c4p" rel="noopener noreferrer"> <paper-button primary>Submit a proposal</paper-button> </a> </div> 
+
+## Why is it cool to speak at the DevFest
+
+DevFest Ukraine is not an ordinary tech conference, besides selecting only the best speakers, we help them to succeed in delivering an exceptional quality talk on the stage. Here are few perks that all our speakers get: 
+
+-   **Expences covered**. Hotel for 3 nights, travel costs and entrance to exclusive speaker parties are covered for all speakers.
+-   **Professional video recording**. We work with experienced video production companies to create session recording of the best quality. Stage, screen, audio, all is recorded separately and combined later. Check the [session videos from the last year](https://www.youtube.com/watch?v=VOwUnBkqmo4).
+-   **Exposure**. By being a speaker, you are proving your level of expertise to a potential business partners or employers. Your talk will be promoted in our online resources and recording published in YouTube channel with more than 35k views.
+-   **Unique networking**. Being a speaker means you’ll have the unique chance to network with other speakers - the best experts in the industry.
+-   **Coaching**. We're in the same boat, after being selected as a speaker our program committee will help you to deliver the best talk possible. We provide information about the audience, presentation templates, feedback on the slides, all to help you to prepare. "It was a best DevFest I ever attended. So professional, so much enthusiasm from the community. You managed to bring the vibe of Google I/O to Ukraine." - David Vávra, DevFest '16 Speaker
+
+## What are we looking for
+
+We're looking for **experience-based talks**, the information that can not be found in the documentation or easily googled. We're looking for your stories, your struggles, research results and experiences with the frontier tools or technologies. Check the [list of topics](https://docs.google.com/document/d/18eGvBr6wdlXsfiZM4EK6SubfL3G1RWj-ABTBN9pngNg/edit?usp=sharing) we're interested in (it is not full and updated all the time). 
+
+### Format
+
+You can submit as many talks as you want. This year we accept submissions in two formats: 
+
+-   40 minutes sessions.
+-   2(or 3) hours workshops.
+
+### Talks that will not pass initial review
+
+-   Talks about a specific tool/library/project explaining how it works or how to use it.
+-   Talks whose focus is pitching a company or project. It’s cool that you mention your company during the presentation, but it shouldn’t be the focus of the talk.
+-   Proposals that are not in English.
+-   Recruitment talks to attract talent. We strongly recommend you check out [speaking.io](http://speaking.io/) website from Zach Holman. It includes good tips and guidelines for speakers.
+
+## Timelines
+
+**Call for Papers submission deadline is July 1, 2017.** Submission results will be announced by July 16. 
+
+Any questions? Email organizers at [devfest@gdg.org.ua](mailto:devfest@gdg.org.ua) 
+
+<div layout horizontal center-justified> <a href="http://bit.ly/df17-c4p" rel="noopener noreferrer"> <paper-button primary>Submit a proposal</paper-button> </a> </div>

--- a/src/pages/post-page.html
+++ b/src/pages/post-page.html
@@ -4,6 +4,7 @@
 <link rel="import" href="../../bower_components/marked-element/marked-element.html">
 <link rel="import" href="../../bower_components/paper-button/paper-button.html">
 <link rel="import" href="../../bower_components/plastic-image/plastic-image.html">
+<link rel="import" href="../../bower_components/iron-ajax/iron-ajax.html">
 
 <link rel="import" href="../mixins/utils-functions.html">
 <link rel="import" href="../mixins/redux-mixin.html">
@@ -96,7 +97,7 @@
     </hero-block>
 
     <div class="container-narrow">
-      <marked-element class="post" markdown="[[post.content]]">
+      <marked-element class="post" markdown="[[postContent]]">
         <div slot="markdown-html"></div>
       </marked-element>
       <div class="date">{$ blog.published $}: [[getDate(post.published)]]</div>
@@ -109,6 +110,7 @@
       </div>
     </div>
 
+    <iron-ajax auto url="[[post.source]]" handle-as="text" on-response="handleMarkdownFileFetch"></iron-ajax>
   </template>
 
   <script>
@@ -160,6 +162,12 @@
         }
       }
 
+      handleMarkdownFileFetch(event) {
+        if (event.detail.response) {
+          this.set('postContent', event.detail.response);
+        }
+      }
+
       _postDataObserver(postId, postsList) {
         if (!this.postsList || !this.postsList.length || !this.postsMap[this.postData.id]) {
           return;
@@ -167,6 +175,7 @@
 
         const post = this.postsMap[this.postData.id];
         this.set('post', post);
+        this.set('postContent', post.content);
         this.set('suggestedPosts', this.postsList
             .filter((post) => post.id !== this.postData.id)
             .slice(0, 3)


### PR DESCRIPTION
I've added support to use local markdown files for blogposts. 

Now the website will first load the markdown inside `post.content` (Markdown stored inside Firestore) and will subsequently try to asynchronously fetch the Markdown file specified in `post.source`. If the request succeed, the fetched markdown will be replaced.

I'm also adding a sample blogpost to test this feature:
<img width="1067" alt="Screenshot 2019-09-03 at 01 54 20" src="https://user-images.githubusercontent.com/3001957/64135942-31a02480-cdee-11e9-9c2f-5efb226fadfc.png">


Fixes #534 