### PR TITLE
Removed Product Sans font usage

### DIFF
--- a/src/elements/shared-styles.html
+++ b/src/elements/shared-styles.html
@@ -71,10 +71,6 @@
         color: var(--primary-text-color);
       }
 
-      .highlight-font {
-        font-family: "Product Sans", arial, sans-serif;
-      }
-
       h1,
       h2,
       h3,
@@ -82,7 +78,6 @@
       h5,
       h6 {
         margin: 0;
-        font-family: "Product Sans", arial, sans-serif;
         font-weight: normal;
       }
 

--- a/src/lazy-resources.html
+++ b/src/lazy-resources.html
@@ -7,4 +7,3 @@
 <link rel="import" href="elements/dialogs/subscribe-dialog.html">
 <link rel="import" href="elements/dialogs/signin-dialog.html">
 <link rel="import" href="elements/polymer-helmet.html">
-<link href="https://fonts.googleapis.com/css?family=Product+Sans:400&amp;lang=en" rel="stylesheet">

--- a/src/pages/blog-list-page.html
+++ b/src/pages/blog-list-page.html
@@ -96,7 +96,7 @@
       font-color="{$ heroSettings.blog.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.blog.title $}</div>
+      <div class="hero-title">{$ heroSettings.blog.title $}</div>
       <p class="hero-description">{$ heroSettings.blog.description $}</p>
     </hero-block>
 

--- a/src/pages/coc-page.html
+++ b/src/pages/coc-page.html
@@ -24,7 +24,7 @@
       font-color="{$ heroSettings.coc.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.coc.title $}</div>
+      <div class="hero-title">{$ heroSettings.coc.title $}</div>
       <p class="hero-description">{$ heroSettings.coc.description $}</p>
     </hero-block>
 

--- a/src/pages/faq-page.html
+++ b/src/pages/faq-page.html
@@ -24,7 +24,7 @@
       font-color="{$ heroSettings.faq.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.faq.title $}</div>
+      <div class="hero-title">{$ heroSettings.faq.title $}</div>
       <p class="hero-description">{$ heroSettings.faq.description $}</p>
     </hero-block>
 

--- a/src/pages/home-page.html
+++ b/src/pages/home-page.html
@@ -141,7 +141,7 @@
     >
       <div class="home-content" layout vertical center>
         <plastic-image class="hero-logo" srcset="/images/logo.svg" alt="{$ title $}"></plastic-image>
-        <div class="info-items highlight-font">
+        <div class="info-items">
           <div class="info-item">{$ location.city $}. {$ dates $}</div>
           <div class="info-item">{$ heroSettings.home.description $}</div>
         </div>

--- a/src/pages/post-page.html
+++ b/src/pages/post-page.html
@@ -92,7 +92,7 @@
       font-color="#fff"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">[[post.title]]</div>
+      <div class="hero-title">[[post.title]]</div>
     </hero-block>
 
     <div class="container-narrow">

--- a/src/pages/previous-speakers-page.html
+++ b/src/pages/previous-speakers-page.html
@@ -134,7 +134,7 @@
       font-color="{$ heroSettings.previousSpeakers.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.previousSpeakers.title $}</div>
+      <div class="hero-title">{$ heroSettings.previousSpeakers.title $}</div>
       <p class="hero-details">{$ heroSettings.previousSpeakers.details $}</p>
     </hero-block>
 

--- a/src/pages/schedule-page.html
+++ b/src/pages/schedule-page.html
@@ -79,7 +79,7 @@
       font-color="{$ heroSettings.schedule.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.schedule.title $}</div>
+      <div class="hero-title">{$ heroSettings.schedule.title $}</div>
       <p class="hero-description">{$ heroSettings.schedule.description $}</p>
       <sticky-element slot="bottom" active="[[active]]">
         <header-bottom-toolbar></header-bottom-toolbar>

--- a/src/pages/speakers-page.html
+++ b/src/pages/speakers-page.html
@@ -176,7 +176,7 @@
       font-color="{$ heroSettings.speakers.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.speakers.title $}</div>
+      <div class="hero-title">{$ heroSettings.speakers.title $}</div>
       <p class="hero-description">{$ heroSettings.speakers.description $}</p>
     </hero-block>
 

--- a/src/pages/team-page.html
+++ b/src/pages/team-page.html
@@ -121,7 +121,7 @@
       font-color="{$ heroSettings.team.fontColor $}"
       active="[[active]]"
     >
-      <div class="hero-title highlight-font">{$ heroSettings.team.title $}</div>
+      <div class="hero-title">{$ heroSettings.team.title $}</div>
       <p class="hero-description">{$ heroSettings.team.description $}</p>
     </hero-block>
 


### PR DESCRIPTION
Product Sans font was removed as well as `.highlight-font` class which only had this font-family defined. Now titles use the website default font.  To fix https://github.com/gdg-x/hoverboard/issues/682