### PR TITLE
Fix failing Firebase initialized in Messaging SW

### DIFF
--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -2,6 +2,7 @@ importScripts('node_modules/firebase/firebase-app.js');
 importScripts('node_modules/firebase/firebase-messaging.js');
 
 firebase.initializeApp({
+  projectId: '{$ firebase.projectId $}',
   messagingSenderId: '{$ firebase.messagingSenderId $}',
 });
 const messaging = firebase.messaging();


### PR DESCRIPTION
Looks like FCM is currently broken on master (The bell icon is always disabled on https://hoverboard-master.firebaseapp.com/).

The Firebase Messaging service worker is initializing the app without the projectId and is causing the failure

Here the stacktrace:
```
Uncaught FirebaseError: Installations: Missing App configuration value: "projectId" (installations/missing-app-config-values).
    at ye (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-messaging.js:1:18861)
    at ge (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-messaging.js:1:18634)
    at y.instanceFactory (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-messaging.js:1:19034)
    at P.getOrInitializeService (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-app.js:1:8189)
    at P.getImmediate (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-app.js:1:6457)
    at y.instanceFactory (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-messaging.js:1:47640)
    at P.getOrInitializeService (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-app.js:1:8189)
    at P.getImmediate (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-app.js:1:6457)
    at G._getService (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-app.js:1:13131)
    at G.messaging (https://hoverboard-master.firebaseapp.com/node_modules/firebase/firebase-app.js:1:15846)
```