### PR TITLE
Fix Image in blogposts to 100% width

### DIFF
--- a/data/posts/2017-02-12-c4p.md
+++ b/data/posts/2017-02-12-c4p.md
@@ -20,6 +20,8 @@ DevFest Ukraine is not an ordinary tech conference, besides selecting only the b
 
 We're looking for **experience-based talks**, the information that can not be found in the documentation or easily googled. We're looking for your stories, your struggles, research results and experiences with the frontier tools or technologies. Check the [list of topics](https://docs.google.com/document/d/18eGvBr6wdlXsfiZM4EK6SubfL3G1RWj-ABTBN9pngNg/edit?usp=sharing) we're interested in (it is not full and updated all the time). 
 
+![sample cfp image](/images/posts/c4p.jpg)
+
 ### Format
 
 You can submit as many talks as you want. This year we accept submissions in two formats: 

--- a/src/pages/post-page.html
+++ b/src/pages/post-page.html
@@ -51,6 +51,10 @@
         margin-bottom: 24px;
       }
 
+      [slot="markdown-html"] img {
+        width: 100%;
+      }
+
       [slot="markdown-html"] plastic-image {
         margin: 32px 0 8px -16px;
         --iron-image-width: calc(100% + 32px);


### PR DESCRIPTION
Currently images in blogposts are occupying too much space and wrongly aligned. Let's fix it:

###  Before
<img width="1792" alt="Screenshot 2020-02-21 at 00 50 21" src="https://user-images.githubusercontent.com/3001957/74990791-82f7ab00-5444-11ea-9ce2-c13ee4d10791.png">

###  After
<img width="1792" alt="Screenshot 2020-02-21 at 00 50 59" src="https://user-images.githubusercontent.com/3001957/74990798-88ed8c00-5444-11ea-978e-4cb3865be4ab.png">

