### PR TITLE
Deploy node_modules as node_assets

### DIFF
--- a/docs/tutorials/00-set-up.md
+++ b/docs/tutorials/00-set-up.md
@@ -26,10 +26,9 @@ The diagram below is a brief summary of the directories within the project.
 
     /
     |---appengine/
-    |---node_modules/
-    |---dist/
     |---config/
     |---data/
+    |---dist/
     |---docs/
     |---functions/
     |---images/

--- a/firebase-messaging-sw.js
+++ b/firebase-messaging-sw.js
@@ -1,5 +1,5 @@
-importScripts('./node_modules/firebase/firebase-app.js');
-importScripts('./node_modules/firebase/firebase-messaging.js');
+importScripts('./node_assets/firebase/firebase-app.js');
+importScripts('./node_assets/firebase/firebase-messaging.js');
 
 firebase.initializeApp({
   apiKey: '{$ firebase.apiKey $}',

--- a/index.html
+++ b/index.html
@@ -100,11 +100,11 @@
       !function(n,e){var t,o,i,c=[],f={passive:!0,capture:!0},r=new Date,a="pointerup",u="pointercancel";function p(n,c){t||(t=c,o=n,i=new Date,w(e),s())}function s(){o>=0&&o<i-r&&(c.forEach(function(n){n(o,t)}),c=[])}function l(t){if(t.cancelable){var o=(t.timeStamp>1e12?new Date:performance.now())-t.timeStamp;"pointerdown"==t.type?function(t,o){function i(){p(t,o),r()}function c(){r()}function r(){e(a,i,f),e(u,c,f)}n(a,i,f),n(u,c,f)}(o,t):p(o,t)}}function w(n){["click","mousedown","keydown","touchstart","pointerdown"].forEach(function(e){n(e,l,f)})}w(n),self.perfMetrics=self.perfMetrics||{},self.perfMetrics.onFirstInputDelay=function(n){c.push(n),s()}}(addEventListener,removeEventListener);
     </script>
 
-    <script src="./node_modules/firebase/firebase-app.js"></script>
-    <script src="./node_modules/firebase/firebase-auth.js"></script>
-    <script src="./node_modules/firebase/firebase-firestore.js"></script>
-    <script src="./node_modules/firebase/firebase-messaging.js"></script>
-    <script src="./node_modules/firebase/firebase-performance.js"></script>
+    <script src="./node_assets/firebase/firebase-app.js"></script>
+    <script src="./node_assets/firebase/firebase-auth.js"></script>
+    <script src="./node_assets/firebase/firebase-firestore.js"></script>
+    <script src="./node_assets/firebase/firebase-messaging.js"></script>
+    <script src="./node_assets/firebase/firebase-performance.js"></script>
 
     <script>
       window.Polymer = { rootPath: '{$ basepath $}' };
@@ -133,7 +133,7 @@
       console.log('Firebase is ready!');
     </script>
 
-    <script src="./node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+    <script src="./node_assets/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
     {% if loadDevelopmentScripts %}
     <!-- TODO: Consolidate development and production builds so they are more similar -->
     <script src="./src/hoverboard-app.ts" type="module"></script>

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -51,11 +51,11 @@ export default deepmerge(config, {
         },
         {
           src: 'node_modules/@webcomponents/webcomponentsjs/*.{js,map}',
-          dest: 'dist/node_modules/@webcomponents/webcomponentsjs',
+          dest: 'dist/node_assets/@webcomponents/webcomponentsjs',
         },
         {
           src: 'node_modules/firebase/*.{js,map}',
-          dest: 'dist/node_modules/firebase/',
+          dest: 'dist/node_assets/firebase/',
         },
         {
           src: 'src/service-worker-registration.js',

--- a/workbox-config.js
+++ b/workbox-config.js
@@ -13,8 +13,7 @@ export const workboxConfig = {
   skipWaiting: true,
   offlineGoogleAnalytics: true,
   globDirectory: path.join(__dirname, 'dist'),
-  globPatterns: ['**/*.{html,js,css,json,svg,md}', 'node_modules/**/*.js'],
-  globIgnores: [], // Enable precaching `node_modules`
+  globPatterns: ['**/*.{html,js,css,json,svg,md}', 'node_assets/**/*.js'],
   runtimeCaching: [
     {
       urlPattern: /\/images\/.*/,
@@ -28,7 +27,7 @@ export const workboxConfig = {
       },
     },
     {
-      urlPattern: /\/node_modules\/.*/,
+      urlPattern: /\/node_assets\/.*/,
       handler: 'NetworkFirst',
       options: {
         cacheName: 'node-modules-cache',


### PR DESCRIPTION
By default tools  usually avoid touching `node_modules` directories. Place needed dependencies in `node_assets` instead and remove tooling workarounds.