### PR TITLE
Add data models

### DIFF
--- a/docs/default-firebase-data.json
+++ b/docs/default-firebase-data.json
@@ -582,7 +582,7 @@
       "complexity": "Intermediate",
       "description": "Storing account information is a common challenge many app developers face, and is often tackled in tailored solutions. Isn't there some strategy to store account credentials in a centralized place?\n\nWhat about considerations for multiple accounts? Security concerns? And when should or could I synchronize data?\n\nAndroid offers a powerful—and underrated—account manager. Let's explore the possibilities together and lay out an architecture for engineering an Android app based on accounts.",
       "language": "English",
-      "speakers": [12],
+      "speakers": ["paul_lammertsma"],
       "tags": ["Android"],
       "title": "I’ve been doing some syncing…"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -7862,6 +7862,12 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
+    "core-js": {
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.6.5.tgz",
+      "integrity": "sha512-vZVEEwZoIsI+vPEuoF9Iqf5H7/M3eeQqWlQnYa8FSKKePuYTf5MWnxb5SDAzCa60b3JBRS5g9b+Dq7b1y/RCrA==",
+      "dev": true
+    },
     "core-js-bundle": {
       "version": "3.6.5",
       "resolved": "https://registry.npmjs.org/core-js-bundle/-/core-js-bundle-3.6.5.tgz",

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@typescript-eslint/eslint-plugin": "^2.34.0",
     "@typescript-eslint/parser": "^2.34.0",
     "concurrently": "^5.2.0",
+    "core-js": "^3.6.5",
     "cross-env": "^7.0.2",
     "deepmerge": "^4.2.2",
     "es-dev-server": "^1.56.0",

--- a/src/models/badge.test.ts
+++ b/src/models/badge.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Badge = import('./badge').Badge;
+
+describe('badge', () => {
+  it('matches the shape of the default data', () => {
+    const badges: Badge[] = Object.values(data['speakers']['dmytro_danylyk']['badges']);
+    const keys: Array<keyof Badge> = ['description', 'link', 'name'];
+    expect(badges).toHaveLength(2);
+    expect(allKeys(badges)).toStrictEqual(keys);
+  });
+});

--- a/src/models/badge.ts
+++ b/src/models/badge.ts
@@ -1,0 +1,5 @@
+export interface Badge {
+  description: string;
+  link: string;
+  name: string;
+}

--- a/src/models/day.test.ts
+++ b/src/models/day.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Day = import('./day').Day;
+
+describe('day', () => {
+  it('matches the shape of the default data', () => {
+    const days: Day[] = Object.values(data['schedule']);
+    const keys: Array<keyof Day> = ['dateReadable', 'timeslots', 'tracks'];
+    expect(days).toHaveLength(2);
+    expect(allKeys(days)).toStrictEqual(keys);
+  });
+});

--- a/src/models/day.ts
+++ b/src/models/day.ts
@@ -1,0 +1,8 @@
+type Timeslot = import('./timeslot').Timeslot;
+type Track = import('./track').Track;
+
+export interface Day {
+  dateReadable: string;
+  timeslots: Timeslot[];
+  tracks: Track[];
+}

--- a/src/models/feedback.test.ts
+++ b/src/models/feedback.test.ts
@@ -1,0 +1,18 @@
+import { allKeys } from './utils';
+
+type Feedback = import('./feedback').Feedback;
+
+describe('feedback', () => {
+  it('matches the shape of the default data', () => {
+    const feedback: Feedback[] = [
+      {
+        comment: 'Super awesome speaker',
+        contentRating: 5,
+        styleRating: 5,
+      },
+    ];
+    const keys: Array<keyof Feedback> = ['comment', 'contentRating', 'styleRating'];
+    expect(feedback).toHaveLength(1);
+    expect(allKeys(feedback)).toStrictEqual(keys);
+  });
+});

--- a/src/models/feedback.ts
+++ b/src/models/feedback.ts
@@ -1,0 +1,5 @@
+export interface Feedback {
+  comment: string;
+  contentRating: number;
+  styleRating: number;
+}

--- a/src/models/hero.test.ts
+++ b/src/models/hero.test.ts
@@ -1,0 +1,19 @@
+import { allKeys } from './utils';
+
+type Hero = import('./hero').Hero;
+
+describe('hero', () => {
+  it('matches the shape of the default data', () => {
+    const heros: Hero[] = [
+      {
+        backgroundColor: '/images/backgrounds/home.jpg',
+        backgroundImage: '#673ab7',
+        fontColor: '#fff',
+        hideLogo: true,
+      },
+    ];
+    const keys: Array<keyof Hero> = ['backgroundColor', 'backgroundImage', 'fontColor', 'hideLogo'];
+    expect(heros).toHaveLength(1);
+    expect(allKeys(heros)).toStrictEqual(keys);
+  });
+});

--- a/src/models/hero.ts
+++ b/src/models/hero.ts
@@ -1,0 +1,6 @@
+export interface Hero {
+  backgroundColor: string;
+  backgroundImage: string;
+  fontColor: string;
+  hideLogo: boolean;
+}

--- a/src/models/logo.test.ts
+++ b/src/models/logo.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Logo = import('./logo').Logo;
+
+describe('logo', () => {
+  it('matches the shape of the default data', () => {
+    const posts: Logo[] = Object.values(data['partners'][1]['logos']);
+    const keys: Array<keyof Logo> = ['logoUrl', 'name', 'order', 'url'];
+    expect(posts).toHaveLength(11);
+    expect(allKeys(posts)).toStrictEqual(keys);
+  });
+});

--- a/src/models/logo.ts
+++ b/src/models/logo.ts
@@ -1,0 +1,6 @@
+export interface Logo {
+  logoUrl: string;
+  name: string;
+  order: number;
+  url: string;
+}

--- a/src/models/member.test.ts
+++ b/src/models/member.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Member = import('./member').Member;
+
+describe('partner', () => {
+  it('matches the shape of the default data', () => {
+    const members: Member[] = Object.values(data['team'][0]['members']);
+    const keys: Array<keyof Member> = ['name', 'order', 'photo', 'photoUrl', 'socials', 'title'];
+    expect(members).toHaveLength(8);
+    expect(allKeys(members)).toStrictEqual(keys);
+  });
+});

--- a/src/models/member.ts
+++ b/src/models/member.ts
@@ -1,0 +1,10 @@
+type Social = import('./social').Social;
+
+export interface Member {
+  name: string;
+  order: number;
+  photo: string;
+  photoUrl: string;
+  socials: Social[];
+  title: string;
+}

--- a/src/models/partner.test.ts
+++ b/src/models/partner.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Partner = import('./partner').Partner;
+
+describe('partner', () => {
+  it('matches the shape of the default data', () => {
+    const partner: Partner[] = Object.values(data['partners']);
+    const keys: Array<keyof Partner> = ['logos', 'order', 'title'];
+    expect(partner).toHaveLength(2);
+    expect(allKeys(partner)).toStrictEqual(keys);
+  });
+});

--- a/src/models/partner.ts
+++ b/src/models/partner.ts
@@ -1,0 +1,7 @@
+type Logo = import('./logo').Logo;
+
+export interface Partner {
+  logos: Logo[];
+  order: number;
+  title: string;
+}

--- a/src/models/post.test.ts
+++ b/src/models/post.test.ts
@@ -1,0 +1,21 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Post = import('./post').Post;
+
+describe('post', () => {
+  it('matches the shape of the default data', () => {
+    const posts: Post[] = Object.values(data['blog']);
+    const keys: Array<keyof Post> = [
+      'backgroundColor',
+      'brief',
+      'content',
+      'image',
+      'published',
+      'source',
+      'title',
+    ];
+    expect(posts).toHaveLength(5);
+    expect(allKeys(posts)).toStrictEqual(keys);
+  });
+});

--- a/src/models/post.ts
+++ b/src/models/post.ts
@@ -1,0 +1,9 @@
+export interface Post {
+  backgroundColor: string;
+  brief: string;
+  content: string;
+  image: string;
+  published: string;
+  source?: string;
+  title: string;
+}

--- a/src/models/previous-session.test.ts
+++ b/src/models/previous-session.test.ts
@@ -1,0 +1,15 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type PreviousSession = import('./previous-session').PreviousSession;
+
+describe('speaker', () => {
+  it('matches the shape of the default data', () => {
+    const sessions: PreviousSession[] = Object.values(
+      data['previousSpeakers']['adrian_kajda']['sessions']['2016']
+    );
+    const keys: Array<keyof PreviousSession> = ['presentation', 'tags', 'title', 'videoId'];
+    expect(sessions).toHaveLength(1);
+    expect(allKeys(sessions)).toStrictEqual(keys);
+  });
+});

--- a/src/models/previous-session.ts
+++ b/src/models/previous-session.ts
@@ -1,0 +1,6 @@
+export interface PreviousSession {
+  presentation?: string;
+  tags: string[];
+  title: string;
+  videoId?: string;
+}

--- a/src/models/previous-speaker.test.ts
+++ b/src/models/previous-speaker.test.ts
@@ -1,0 +1,25 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type PreviousSpeaker = import('./previous-speaker').PreviousSpeaker;
+
+describe('speaker', () => {
+  it('matches the shape of the default data', () => {
+    const speakers: PreviousSpeaker[] = Object.values(data['previousSpeakers']);
+    const keys: Array<keyof PreviousSpeaker> = [
+      'bio',
+      'company',
+      'companyLogo',
+      'country',
+      'id',
+      'name',
+      'order',
+      'photoUrl',
+      'sessions',
+      'socials',
+      'title',
+    ];
+    expect(speakers).toHaveLength(22);
+    expect(allKeys(speakers)).toStrictEqual(keys);
+  });
+});

--- a/src/models/previous-speaker.ts
+++ b/src/models/previous-speaker.ts
@@ -1,0 +1,16 @@
+type Social = import('./social').Social;
+type PreviousSession = import('./previous-session').PreviousSession;
+
+export interface PreviousSpeaker {
+  bio: string;
+  company: string;
+  companyLogo?: string;
+  country: string;
+  id: string;
+  name: string;
+  order: number;
+  photoUrl: string;
+  sessions?: { [key: string]: PreviousSession[] };
+  socials: Social[];
+  title: string;
+}

--- a/src/models/schedule.ts
+++ b/src/models/schedule.ts
@@ -1,0 +1,5 @@
+type Day = import('./day').Day;
+
+export interface Schedule {
+  [key: string]: Day;
+}

--- a/src/models/session.test.ts
+++ b/src/models/session.test.ts
@@ -1,0 +1,25 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Session = import('./session').Session;
+
+describe('session', () => {
+  it('matches the shape of the default data', () => {
+    const sessions: Session[] = Object.values(data['sessions']);
+    const keys: Array<keyof Session> = [
+      'complexity',
+      'description',
+      'extend',
+      'icon',
+      'image',
+      'language',
+      'presentation',
+      'speakers',
+      'tags',
+      'title',
+      'videoId',
+    ];
+    expect(sessions).toHaveLength(40);
+    expect(allKeys(sessions)).toStrictEqual(keys);
+  });
+});

--- a/src/models/session.ts
+++ b/src/models/session.ts
@@ -1,0 +1,13 @@
+export interface Session {
+  complexity?: string;
+  description: string;
+  extend?: number;
+  icon?: string;
+  image?: string;
+  language?: string;
+  presentation?: string;
+  speakers?: string[];
+  tags?: string[];
+  title: string;
+  videoId?: string;
+}

--- a/src/models/social.test.ts
+++ b/src/models/social.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Social = import('./social').Social;
+
+describe('speaker', () => {
+  it('matches the shape of the default data', () => {
+    const socials: Social[] = Object.values(data['speakers']['aleksander_piotrowski']['socials']);
+    const keys: Array<keyof Social> = ['icon', 'link', 'name'];
+    expect(socials).toHaveLength(4);
+    expect(allKeys(socials)).toStrictEqual(keys);
+  });
+});

--- a/src/models/social.ts
+++ b/src/models/social.ts
@@ -1,0 +1,5 @@
+export interface Social {
+  icon: string;
+  link: string;
+  name: string;
+}

--- a/src/models/speaker.test.ts
+++ b/src/models/speaker.test.ts
@@ -1,0 +1,29 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Speaker = import('./speaker').Speaker;
+
+describe('speaker', () => {
+  it('matches the shape of the default data', () => {
+    const speakers: Speaker[] = Object.values(data['speakers']);
+    const keys: Array<keyof Speaker> = [
+      'badges',
+      'bio',
+      'company',
+      'companyLogo',
+      'companyLogoUrl',
+      'country',
+      'featured',
+      'name',
+      'order',
+      'photo',
+      'photoUrl',
+      'pronouns',
+      'shortBio',
+      'socials',
+      'title',
+    ];
+    expect(speakers).toHaveLength(27);
+    expect(allKeys(speakers)).toStrictEqual(keys);
+  });
+});

--- a/src/models/speaker.ts
+++ b/src/models/speaker.ts
@@ -1,0 +1,20 @@
+type Badge = import('./badge').Badge;
+type Social = import('./social').Social;
+
+export interface Speaker {
+  badges?: Badge[];
+  bio: string;
+  company: string;
+  companyLogo: string;
+  companyLogoUrl: string;
+  country: string;
+  featured: boolean;
+  name: string;
+  order: number;
+  photo: string;
+  photoUrl: string;
+  pronouns?: string;
+  shortBio: string;
+  socials: Social[];
+  title: string;
+}

--- a/src/models/team.test.ts
+++ b/src/models/team.test.ts
@@ -1,0 +1,14 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Team = import('./team').Team;
+
+describe('partner', () => {
+  it('matches the shape of the default data', () => {
+    const teams: Team[] = Object.values(data['team']);
+    const keys: Array<keyof Team> = ['members', 'title'];
+    expect(teams).toHaveLength(2);
+    expect(allKeys(teams)).toStrictEqual(keys);
+  });
+});
+'';

--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -1,0 +1,6 @@
+type Member = import('./member').Member;
+
+export interface Team {
+  members: Member[];
+  title: string;
+}

--- a/src/models/ticket.test.ts
+++ b/src/models/ticket.test.ts
@@ -1,0 +1,26 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Ticket = import('./ticket').Ticket;
+
+describe('ticket', () => {
+  it('matches the shape of the default data', () => {
+    const tickets: Ticket[] = Object.values(data['tickets']);
+    const keys: Array<keyof Ticket> = [
+      'available',
+      'currency',
+      'ends',
+      'inDemand',
+      'info',
+      'name',
+      'price',
+      'primary',
+      'regular',
+      'soldOut',
+      'starts',
+      'url',
+    ];
+    expect(tickets).toHaveLength(5);
+    expect(allKeys(tickets)).toStrictEqual(keys);
+  });
+});

--- a/src/models/ticket.ts
+++ b/src/models/ticket.ts
@@ -1,0 +1,14 @@
+export interface Ticket {
+  available: boolean;
+  currency: string;
+  ends?: string;
+  inDemand?: boolean;
+  info: string;
+  name: string;
+  price: number;
+  primary?: boolean;
+  regular?: boolean;
+  soldOut: boolean;
+  starts?: string;
+  url: string;
+}

--- a/src/models/time.test.ts
+++ b/src/models/time.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Time = import('./time').Time;
+
+describe('time', () => {
+  it('matches the shape of the default data', () => {
+    const times: Time[] = data['schedule']['2016-09-09']['timeslots'][3]['sessions'];
+    const keys: Array<keyof Time> = ['extend', 'items'];
+    expect(times).toHaveLength(3);
+    expect(allKeys(times)).toStrictEqual(keys);
+  });
+});

--- a/src/models/time.ts
+++ b/src/models/time.ts
@@ -1,0 +1,4 @@
+export interface Time {
+  extend?: number;
+  items: number[];
+}

--- a/src/models/timeslot.test.ts
+++ b/src/models/timeslot.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Timeslot = import('./timeslot').Timeslot;
+
+describe('timeslot', () => {
+  it('matches the shape of the default data', () => {
+    const days: Timeslot[] = data['schedule']['2016-09-09']['timeslots'];
+    const keys: Array<keyof Timeslot> = ['endTime', 'sessions', 'startTime'];
+    expect(days).toHaveLength(13);
+    expect(allKeys(days)).toStrictEqual(keys);
+  });
+});

--- a/src/models/timeslot.ts
+++ b/src/models/timeslot.ts
@@ -1,0 +1,7 @@
+type Time = import('./time').Time;
+
+export interface Timeslot {
+  endTime: string;
+  sessions: Time[];
+  startTime: string;
+}

--- a/src/models/toast.test.ts
+++ b/src/models/toast.test.ts
@@ -1,0 +1,27 @@
+import { allKeys } from './utils';
+
+type Toast = import('./toast').Toast;
+
+describe('toast', () => {
+  it('matches the shape of the default data', () => {
+    const feedback: Toast[] = [
+      {
+        message: 'Super awesome notification',
+      },
+      {
+        duration: 1,
+        message: 'Quick notification',
+      },
+      {
+        action: {
+          title: 'This is being logged',
+          callback: console.log,
+        },
+        message: 'Log',
+      },
+    ];
+    const keys: Array<keyof Toast> = ['action', 'duration', 'message'];
+    expect(feedback).toHaveLength(3);
+    expect(allKeys(feedback)).toStrictEqual(keys);
+  });
+});

--- a/src/models/toast.ts
+++ b/src/models/toast.ts
@@ -1,0 +1,11 @@
+// TODO: Move to file
+interface Action {
+  title: string;
+  callback: () => void;
+}
+
+export interface Toast {
+  action?: Action;
+  duration?: number;
+  message: string;
+}

--- a/src/models/track.test.ts
+++ b/src/models/track.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Track = import('./track').Track;
+
+describe('track', () => {
+  it('matches the shape of the default data', () => {
+    const days: Track[] = data['schedule']['2016-09-09']['tracks'];
+    const keys: Array<keyof Track> = ['title'];
+    expect(days).toHaveLength(3);
+    expect(allKeys(days)).toStrictEqual(keys);
+  });
+});

--- a/src/models/track.ts
+++ b/src/models/track.ts
@@ -1,0 +1,3 @@
+export interface Track {
+  title: string;
+}

--- a/src/models/tsconfig.json
+++ b/src/models/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.strict"
+}

--- a/src/models/user.test.ts
+++ b/src/models/user.test.ts
@@ -1,0 +1,49 @@
+import { isAuthenticated, isUnauthenticated } from './user';
+import { allKeys } from './utils';
+
+type User = import('./user').User;
+type AuthenticatedUser = import('./user').AuthenticatedUser;
+type UnauthenticatedUser = import('./user').UnauthenticatedUser;
+
+const users: User[] = [
+  {
+    signedIn: false,
+  },
+  {
+    signedIn: true,
+    uid: 'abcxyz',
+    email: 'sam@example.com',
+    displayName: 'Sam Smith',
+    photoURL: 'https://example.com/sam.jpg',
+    refreshToken: 'xyzabc',
+    initialProviderId: 'google.com',
+  },
+];
+
+describe('user', () => {
+  describe('authenticated', () => {
+    it('matches the shape of the default data', () => {
+      const authenticatedUsers: AuthenticatedUser[] = users.filter(isAuthenticated);
+      const keys: Array<keyof AuthenticatedUser> = [
+        'displayName',
+        'email',
+        'initialProviderId',
+        'photoURL',
+        'refreshToken',
+        'signedIn',
+        'uid',
+      ];
+      expect(authenticatedUsers).toHaveLength(1);
+      expect(allKeys(authenticatedUsers)).toStrictEqual(keys);
+    });
+  });
+
+  describe('unauthenticated', () => {
+    it('matches the shape of the default data', () => {
+      const unauthenticatedUsers: UnauthenticatedUser[] = users.filter(isUnauthenticated);
+      const keys: Array<keyof UnauthenticatedUser> = ['signedIn'];
+      expect(unauthenticatedUsers).toHaveLength(1);
+      expect(allKeys(unauthenticatedUsers)).toStrictEqual(keys);
+    });
+  });
+});

--- a/src/models/user.ts
+++ b/src/models/user.ts
@@ -1,0 +1,23 @@
+export interface UnauthenticatedUser {
+  signedIn: false;
+}
+
+export interface AuthenticatedUser {
+  displayName: string;
+  email: string;
+  initialProviderId: string;
+  photoURL: string;
+  refreshToken: string;
+  signedIn: true;
+  uid: string;
+}
+
+export type User = UnauthenticatedUser | AuthenticatedUser;
+
+export const isAuthenticated = (user: User): user is AuthenticatedUser => {
+  return user.signedIn;
+};
+
+export const isUnauthenticated = (user: User): user is UnauthenticatedUser => {
+  return !user.signedIn;
+};

--- a/src/models/utils.ts
+++ b/src/models/utils.ts
@@ -1,0 +1,7 @@
+import 'core-js/features/array/flat-map';
+
+export const allKeys = <T>(values: T[]) => {
+  const keys = values.flatMap((value) => Object.keys(value));
+
+  return [...new Set(keys)].sort();
+};

--- a/src/models/video.test.ts
+++ b/src/models/video.test.ts
@@ -1,0 +1,13 @@
+import data from '../../docs/default-firebase-data.json';
+import { allKeys } from './utils';
+
+type Video = import('./video').Video;
+
+describe('video', () => {
+  it('matches the shape of the default data', () => {
+    const videos: Video[] = Object.values(data['videos']);
+    const keys: Array<keyof Video> = ['speakers', 'thumbnail', 'title', 'youtubeId'];
+    expect(videos).toHaveLength(22);
+    expect(allKeys(videos)).toStrictEqual(keys);
+  });
+});

--- a/src/models/video.ts
+++ b/src/models/video.ts
@@ -1,0 +1,6 @@
+export interface Video {
+  speakers: string;
+  thumbnail: string;
+  title: string;
+  youtubeId: string;
+}

--- a/src/redux/actions.ts
+++ b/src/redux/actions.ts
@@ -94,7 +94,7 @@ export const uiActions = {
       value,
     });
   },
-  setHeroSettings: (value) => {
+  setHeroSettings: (value: import('../models/hero').Hero) => {
     store.dispatch({
       type: SET_HERO_SETTINGS,
       value,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     // "incremental": true,                   /* Enable incremental compilation */
     "target": "es2018" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
     "module": "esnext" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
-    "lib": ["es2017", "dom"] /* Specify library files to be included in the compilation. */,
+    "lib": ["es2020", "dom"] /* Specify library files to be included in the compilation. */,
     "allowJs": true /* Allow javascript files to be compiled. */,
     // "checkJs": true,                       /* Report errors in .js files. */
     // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
@@ -61,7 +61,9 @@
     // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
 
     /* Advanced Options */
-    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+    "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */,
+
+    "resolveJsonModule": true
   },
   "compileOnSave": true,
   "include": ["**/*.ts"]


### PR DESCRIPTION
Adds interfaces for all all the data models in `default-firebase-data.json` although most of the types are not being used yet.

Closes #637

The tests assert that unique keys found the JSON file is in an array of known keys. TypeScript asserts that they values in that array are all in the keys of the defined interface.