### PR TITLE
Setup a pre-merge & deploy Github Action

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -27,7 +27,7 @@ jobs:
           node-version: 10
 
       - name: Installing Dependencencies
-        run: npm install
+        run: npm ci
 
       - name: Building the project
         run: npm run build

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -33,7 +33,7 @@ jobs:
         run: npm run build
 
       - name: Deploy to Firebase
-        uses: w9jds/firebase-action@master
+        uses: w9jds/firebase-action@v1.3.0
         with:
           args: deploy
         env:

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -38,5 +38,5 @@ jobs:
           args: deploy
         env:
           # Change your project ID here according to your configuration
-          PROJECT_ID: hoverboard-master
+          PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -37,6 +37,6 @@ jobs:
         with:
           args: deploy
         env:
-          # Change your project ID here according to your configuration
+          # Update your project ID and Token in the secrets of your repo settings
           PROJECT_ID: ${{ secrets.FIREBASE_PROJECT_ID }}
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - 'master'
-      - 'develop'
 
 jobs:
   deploy:
@@ -33,18 +32,7 @@ jobs:
       - name: Building the project
         run: npm run build
 
-      - name: Deploy to Development Environment
-        if: github.ref == 'refs/heads/develop'
-        uses: w9jds/firebase-action@master
-        with:
-          args: deploy
-        env:
-          # Change your project ID here according to your configuration
-          PROJECT_ID: hoverboard-dev
-          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-
-      - name: Deploy to Master Environment
-        if: github.ref == 'refs/heads/master'
+      - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
         with:
           args: deploy

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,54 @@
+name: Deploy to Firebase
+
+on:
+  push:
+    branches:
+      - 'master'
+      - 'develop'
+
+jobs:
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 10
+
+      - name: Installing Dependencencies
+        run: npm install
+
+      - name: Building the project
+        run: npm run build
+
+      - name: Deploy to Development Environment
+        if: github.ref == 'refs/heads/develop'
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy
+        env:
+          # Change your project ID here according to your configuration
+          PROJECT_ID: hoverboard-dev
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+
+      - name: Deploy to Master Environment
+        if: github.ref == 'refs/heads/master'
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy
+        env:
+          # Change your project ID here according to your configuration
+          PROJECT_ID: hoverboard-master
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -32,7 +32,12 @@ jobs:
       - name: Install dependencies
         run: npm install
 
-      - name: Building the project
+      - name: Building the development environment
+        run: npm run build
+        env:
+          NODE_ENV: development
+
+      - name: Building the production environment
         run: npm run build
 
       - name: Running the linter

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,0 +1,41 @@
+name: Pre Merge Checks
+on: 
+  push:
+    branches: 
+      - '*'
+  pull_request:
+    branches: 
+      - '*'
+
+jobs:
+  npm:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: [ '10', '12' ]
+    name: Node ${{ matrix.node-version }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Npm install
+        run: npm install
+
+      - name: Building the project
+        run: npm run build
+
+      - name: Running the linter
+        run: npm run lint
+
+      - name: Running the security audit
+        run: npm audit && npm audit --prefix functions
+        continue-on-error: true
+
+      - name: Running the tests
+        run: npm run test

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,10 +1,10 @@
 name: Pre Merge Checks
-on: 
+on:
   push:
-    branches: 
+    branches:
       - '*'
   pull_request:
-    branches: 
+    branches:
       - '*'
 
 jobs:
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: [ '10', '12' ]
+        node-version: ['10', '12']
     name: Node ${{ matrix.node-version }}
     steps:
       - name: Checkout the repo

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -5,13 +5,13 @@ on:
       - '*'
 
 jobs:
-  npm:
+  build:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         node-version: ['10', '12']
-    name: Node ${{ matrix.node-version }}
+    name: Build & Test on Node ${{ matrix.node-version }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -1,8 +1,5 @@
 name: Pre Merge Checks
 on:
-  push:
-    branches:
-      - '*'
   pull_request:
     branches:
       - '*'

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['10', '12']
+        node-version: [10, 12]
     name: Build & Test on Node ${{ matrix.node-version }}
     steps:
       - name: Checkout the repo

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -30,7 +30,7 @@ jobs:
           node-version: ${{ matrix.node-version }}
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
 
       - name: Building the development environment
         run: npm run build

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -29,7 +29,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Npm install
+      - name: Install dependencies
         run: npm install
 
       - name: Building the project

--- a/.github/workflows/pre-merge.yaml
+++ b/.github/workflows/pre-merge.yaml
@@ -16,6 +16,14 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
 
+      - name: Cache node modules
+        uses: actions/cache@v1
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-
+
       - name: Setup node
         uses: actions/setup-node@v1
         with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,25 +17,25 @@ jobs:
     - stage: Test
       name: Test
       script: npm test
-    - stage: Deploy
-      name: Firebase
-      script: if [ "$TRAVIS_BRANCH" == "master" ]; then npm run build; else BUILD_ENV=development npm run build; fi
-      before_deploy:
-        - echo "Deploying!"
-      deploy:
-        - provider: firebase
-          skip_cleanup: true
-          on:
-            branch: master
-          project: hoverboard-master
-          token:
-            secure: 'J7nrIZcUndOsZLPG8U/6qPXfYo3XDu5brEoTM3pJOpy5NLVYVrCO4ewn/hcldyJWR7TmJ4SLGti+gxOSt3kRRqgSLLNB2Xsd2t+jL6l2PhHobad+T0oGuHyhYFtidISWh4C5lJp1NGxBJGeeVos2vEU6qNADseKCdvvx7CVcMa0oSgLE21sNyMeggvoHKuWnFYzI+1Glwau5zaVLCwj9mObEFkuYwxF8YIoTigkdemQg+b2k4fO/L8ohgs/a+WCVKxeg5VfagO9rwg+XKGiF9IjTBFuaJSghSoSQTGiqol6FY7czN/64xbXOFFPAvL6dS3RbaA6l1bxRbD7h/oC3/No4T3wKwVI68dnNstbNcHMtGdgoFJTaJMVn8Wg2gnWGeTxukDlfLyoEKmsMMWVN5GP2KvWaVF51vZBQfJaMSJ9YaFFs4yjYPydZmKgYMrH8a7eoR5aGEfntPZCULIJneTwj0NtwfCirLYsLQXCbkxRJNBOVNoEEdyASazVgQ08qC+pA9XO5pJuT0ozqeq5KlxznGYcxmrP54QQj58tYSCU72Ic5VVRBlZhfl+wm5254SMOHXJ63N74HZmpXJfN9nj1I2b0bHWDZ8AFakzn9XF5Kb7UDJJQ+tYJWZ6ijpTDn+L8EAlklcUnTHFOaVaQgf5TTLUWgs8C37joOd2XqX74='
-        - provider: firebase
-          skip_cleanup: true
-          on:
-            branch: develop
-          project: hoverboard-dev
-          token:
-            secure: 'J7nrIZcUndOsZLPG8U/6qPXfYo3XDu5brEoTM3pJOpy5NLVYVrCO4ewn/hcldyJWR7TmJ4SLGti+gxOSt3kRRqgSLLNB2Xsd2t+jL6l2PhHobad+T0oGuHyhYFtidISWh4C5lJp1NGxBJGeeVos2vEU6qNADseKCdvvx7CVcMa0oSgLE21sNyMeggvoHKuWnFYzI+1Glwau5zaVLCwj9mObEFkuYwxF8YIoTigkdemQg+b2k4fO/L8ohgs/a+WCVKxeg5VfagO9rwg+XKGiF9IjTBFuaJSghSoSQTGiqol6FY7czN/64xbXOFFPAvL6dS3RbaA6l1bxRbD7h/oC3/No4T3wKwVI68dnNstbNcHMtGdgoFJTaJMVn8Wg2gnWGeTxukDlfLyoEKmsMMWVN5GP2KvWaVF51vZBQfJaMSJ9YaFFs4yjYPydZmKgYMrH8a7eoR5aGEfntPZCULIJneTwj0NtwfCirLYsLQXCbkxRJNBOVNoEEdyASazVgQ08qC+pA9XO5pJuT0ozqeq5KlxznGYcxmrP54QQj58tYSCU72Ic5VVRBlZhfl+wm5254SMOHXJ63N74HZmpXJfN9nj1I2b0bHWDZ8AFakzn9XF5Kb7UDJJQ+tYJWZ6ijpTDn+L8EAlklcUnTHFOaVaQgf5TTLUWgs8C37joOd2XqX74='
+    # - stage: Deploy
+    #   name: Firebase
+    #   script: if [ "$TRAVIS_BRANCH" == "master" ]; then npm run build; else BUILD_ENV=development npm run build; fi
+    #   before_deploy:
+    #     - echo "Deploying!"
+    #   deploy:
+    #     - provider: firebase
+    #       skip_cleanup: true
+    #       on:
+    #         branch: master
+    #       project: hoverboard-master
+    #       token:
+    #         secure: 'J7nrIZcUndOsZLPG8U/6qPXfYo3XDu5brEoTM3pJOpy5NLVYVrCO4ewn/hcldyJWR7TmJ4SLGti+gxOSt3kRRqgSLLNB2Xsd2t+jL6l2PhHobad+T0oGuHyhYFtidISWh4C5lJp1NGxBJGeeVos2vEU6qNADseKCdvvx7CVcMa0oSgLE21sNyMeggvoHKuWnFYzI+1Glwau5zaVLCwj9mObEFkuYwxF8YIoTigkdemQg+b2k4fO/L8ohgs/a+WCVKxeg5VfagO9rwg+XKGiF9IjTBFuaJSghSoSQTGiqol6FY7czN/64xbXOFFPAvL6dS3RbaA6l1bxRbD7h/oC3/No4T3wKwVI68dnNstbNcHMtGdgoFJTaJMVn8Wg2gnWGeTxukDlfLyoEKmsMMWVN5GP2KvWaVF51vZBQfJaMSJ9YaFFs4yjYPydZmKgYMrH8a7eoR5aGEfntPZCULIJneTwj0NtwfCirLYsLQXCbkxRJNBOVNoEEdyASazVgQ08qC+pA9XO5pJuT0ozqeq5KlxznGYcxmrP54QQj58tYSCU72Ic5VVRBlZhfl+wm5254SMOHXJ63N74HZmpXJfN9nj1I2b0bHWDZ8AFakzn9XF5Kb7UDJJQ+tYJWZ6ijpTDn+L8EAlklcUnTHFOaVaQgf5TTLUWgs8C37joOd2XqX74='
+    #     - provider: firebase
+    #       skip_cleanup: true
+    #       on:
+    #         branch: develop
+    #       project: hoverboard-dev
+    #       token:
+    #         secure: 'J7nrIZcUndOsZLPG8U/6qPXfYo3XDu5brEoTM3pJOpy5NLVYVrCO4ewn/hcldyJWR7TmJ4SLGti+gxOSt3kRRqgSLLNB2Xsd2t+jL6l2PhHobad+T0oGuHyhYFtidISWh4C5lJp1NGxBJGeeVos2vEU6qNADseKCdvvx7CVcMa0oSgLE21sNyMeggvoHKuWnFYzI+1Glwau5zaVLCwj9mObEFkuYwxF8YIoTigkdemQg+b2k4fO/L8ohgs/a+WCVKxeg5VfagO9rwg+XKGiF9IjTBFuaJSghSoSQTGiqol6FY7czN/64xbXOFFPAvL6dS3RbaA6l1bxRbD7h/oC3/No4T3wKwVI68dnNstbNcHMtGdgoFJTaJMVn8Wg2gnWGeTxukDlfLyoEKmsMMWVN5GP2KvWaVF51vZBQfJaMSJ9YaFFs4yjYPydZmKgYMrH8a7eoR5aGEfntPZCULIJneTwj0NtwfCirLYsLQXCbkxRJNBOVNoEEdyASazVgQ08qC+pA9XO5pJuT0ozqeq5KlxznGYcxmrP54QQj58tYSCU72Ic5VVRBlZhfl+wm5254SMOHXJ63N74HZmpXJfN9nj1I2b0bHWDZ8AFakzn9XF5Kb7UDJJQ+tYJWZ6ijpTDn+L8EAlklcUnTHFOaVaQgf5TTLUWgs8C37joOd2XqX74='
   allow_failures:
     - name: Security

--- a/docs/tutorials/04-deploy.md
+++ b/docs/tutorials/04-deploy.md
@@ -30,8 +30,8 @@ BUILD_ENV=custom npm run deploy
 
 In the [`.github/workflows`](.github/workflows) folder, you can find two workflows to help you develop and deploy Hoverboard to Firebase:
 
-* [`pre-merge.yaml`](.github/workflows/pre-merge.yaml) Builds the project, runs the linter and the tests on every Pull Request
-* [`deploy.yaml`](.github/workflows/deploy.yaml) Deploys the project to Firebase after every merge to `master`.
+- [`pre-merge.yaml`](.github/workflows/pre-merge.yaml) Builds the project, runs the linter and the tests on every Pull Request
+- [`deploy.yaml`](.github/workflows/deploy.yaml) Deploys the project to Firebase after every merge to `master`.
 
 The `pre-merge` workflow is already configured and will work out of the box, once you fork the hoverboard repo.
 To run the `deploy` on your instance instead, you need to do a small setup:
@@ -55,7 +55,7 @@ Once you obtained the token, you need to store it as a **secret** called `FIREBA
 More details on this process can be found here: [Creating and storing encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).
 
 Finally, you need to update your `project-id` inside the `deploy.yaml` file to match your project ID where you want to publish:
- 
+
     ```yaml
       - name: Deploy to Firebase
         uses: w9jds/firebase-action@master
@@ -66,7 +66,7 @@ Finally, you need to update your `project-id` inside the `deploy.yaml` file to m
           PROJECT_ID: hoverboard-master
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
     ```
-    
+
 So you can replace `hoverboard-master` with your specific project ID.
 
 Push this change to `master`, and Github Actions will deploy your project to Firebase after every commit.

--- a/docs/tutorials/04-deploy.md
+++ b/docs/tutorials/04-deploy.md
@@ -2,27 +2,27 @@
 
 1.  Create [Firebase account](https://console.firebase.google.com) and login into [Firebase CLI](https://firebase.google.com/docs/cli/):
 
-    ```console
-      npx firebase login
-    ```
+```bash
+npx firebase login
+```
 
 1.  Select the Firebase project to deploy to
 
-    ```console
-      npx firebase use <projectId>
-    ```
+```bash
+npx firebase use <projectId>
+```
 
 1.  Build and deploy with `/config/production.json`
 
-    ```console
-      npm run deploy
-    ```
+```bash
+npm run deploy
+```
 
     or to deploy with a custom config pass the name of the config file. For example with `/config/custom.json`
 
-    ```console
-      BUILD_ENV=custom npm run deploy
-    ```
+```bash
+BUILD_ENV=custom npm run deploy
+```
 
     The URL to your live site is listed in the output.
 
@@ -40,16 +40,16 @@ To run the `deploy` on your instance instead, you need to do a small setup:
 
 First, make sure that you're able to deploy locally correctly with the command:
 
-    ```console
-      npm run deploy
-    ```
+```bash
+npm run deploy
+```
 
 If the deploy is successful, you can then configure Github Actions to do it for you.
 You need to generate a login token for the CI with the following command:
 
-    ```console
-      npx firebase login:ci
-    ```
+```bash
+npx firebase login:ci
+```
 
 Once you obtained the token, you need to store it as a **secret** called `FIREBASE_TOKEN` in the settings of your repository.
 More details on this process can be found here: [Creating and storing encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).

--- a/docs/tutorials/04-deploy.md
+++ b/docs/tutorials/04-deploy.md
@@ -26,71 +26,49 @@
 
     The URL to your live site is listed in the output.
 
-### Continuous integration with Travis CI
+### Continuous integration with Github Actions
 
-In the root folder, you can find [.travis.yml](/.travis.yml) which configures
-[Travis CI][travis ci] build and deployment on Firebase hosting:
+In the [`.github/workflows`](.github/workflows) folder, you can find two workflows to help you develop and deploy Hoverboard to Firebase:
 
-```yaml
-- provider: firebase
-  skip_cleanup: true
-  on:
-    branch: master # on which branch trigger build
-  project: hoverboard # Firebase project name
-  token:
-    secure: Quq/Ys1GKDYFjqMCD107saKj005L0RaM7Ian9yLIW/er4KdMzwjYw7TVXmtMeJPIfEy/e2/4WJ63K1SaXieBoFndoUcpGWqPOoTrnkkj5K7tzeZKM32XqIarF+BNmOoqW5M7+kuN8L7N3RLp00ywFDOgKgiZJeoaDV6sIRRAIFVh+xHWabVWpFCwCUSeBZpufOsZhMXkicyRe0XhMmkUvS1P5CI3AyZZdIfWG+sguFsPOWRjMFKWrbnsilDFDjf7N0Wd8Z1H2Z0LBn/V00bNb95MSIuOhkdk3a1wP0P5Eollet+Y8g+NpdWyFq0/C+6+ECvFLBjtvbtMY1BVfdxkCo5XlogZx31OmkMWVX6PXOD5Va8aFoJnwvjovUT8oZbSCWEuyMxI91jDsLxXZt542MNfUfQ1Q2+SpUShdcRlwoV2c/XOYvme95HnI1LSqzLubooKWxz8wpa/aovkdZbum54t/z5nA54AXN1lYKsi+hcAFHOeucqd/kHOLG0bx05Ev86wcvNH8qGx+v7S644YH37No7PGnKU3g3Jq/m6quo1B/bMEIaatVnR40D301wAi8tsNWnqEdWFKnAlGrTIDd1qek9OHnApmgBQI8o0FOy6WbzLMwl9PnMl+t+wew/ggSY0IdWhjFWR/S1d6xML8cYHXHVpE0wxkat5ETbIYXlg=
-```
+* [`pre-merge.yaml`](.github/workflows/pre-merge.yaml) Builds the project, runs the linter and the tests on every Pull Request
+* [`deploy.yaml`](.github/workflows/deploy.yaml) Deploys the project to Firebase after every merge to `master`.
 
-To generate the `secure` value do the following steps:
+The `pre-merge` workflow is already configured and will work out of the box, once you fork the hoverboard repo.
+To run the `deploy` on your instance instead, you need to do a small setup:
 
-1. Log in to Firebase console
+#### Deploying to Firebase wiht Github Actions
 
-   ```console
-     npx firebase login:ci --interactive
-   ```
+First, make sure that you're able to deploy locally correctly with the command:
 
-   You will get your token:
+    ```console
+      npm run deploy
+    ```
 
-   ```console
-       ✔  Success! Use this token to log in on a CI server:
+If the deploy is successful, you can then configure Github Actions to do it for you.
+You need to generate a login token for the CI with the following command:
 
-       1/9YmsNEh87G3cRyt_FXQbsYI_uV4FUMmUBXkbl_CHANGED
-   ```
+    ```console
+      npx firebase login:ci
+    ```
 
-1. Install travis tool to encrypt the token
+Once you obtained the token, you need to store it as a **secret** called `FIREBASE_TOKEN` in the settings of your repository.
+More details on this process can be found here: [Creating and storing encrypted secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets).
 
-   ```console
-     gem install travis
-   ```
+Finally, you need to update your `project-id` inside the `deploy.yaml` file to match your project ID where you want to publish:
+ 
+    ```yaml
+      - name: Deploy to Firebase
+        uses: w9jds/firebase-action@master
+        with:
+          args: deploy
+        env:
+          # Change your project ID here according to your configuration
+          PROJECT_ID: hoverboard-master
+          FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
+    ```
+    
+So you can replace `hoverboard-master` with your specific project ID.
 
-1. Log in to your account
+Push this change to `master`, and Github Actions will deploy your project to Firebase after every commit.
 
-   ```console
-     travis login --auto
-   ```
-
-1. Encrypt your token
-
-   ```console
-     travis encrypt "1/9YmsNEh87G3cRyt_FXQbsYI_uV4FUMmUBXkbl_CHANGED"
-   ```
-
-   Approximate output:
-
-   ```console
-     secure: "cioDQ571EZpnuGiDn7ofvEghNFP82vz7N+SqIL5ZjOK0CBgaWO3OoePoh1eO1dvIsdLDr7yNs5kBIx8NIuOqUA9YLyIIasC7ah1QLtiK5zRVaCcgwt4aBqRLKJVbXPl08MIyk9GFYl2+J+oLOzoEOnVUuCpUcGYWdmDRTKis5KP6naK1msRmTu5ymQn55cyxpmSZS2F+iEsAgV7d0/h+HGgPPd77M26j8wV9JEFJp3iMhudaCkWdoBf9z9WP0cpPzTHgSHEU/Mski4oMfU1BqCFRiaKfcw/uLzMcTpjcf+YG2dc3qTMcuBNKNvhANnaYrxePtuW1VWb+xl19qVQWrsGpQgyWIbp+icSXF3KGR1wfNrC9zNQWKm112BckYn6id8w4M3JeRdWRaCwWitG9C5CWQ3ZepPpgBu2SYSfZQg5heIbVSYOgbXUfeR8ByJqyAGCrYrB3lyyR49cr+GAnILbOgxE7FRYuHmagLD+xa8cHUFcZUu6CxgrhOFa+28Lvrtvod1WqbIioZfhWRcdIZNdJxR4gxXaGycp5n0qjJ0o1VDFAUcy93ImYyVZFY+OmqfVLFQChAD9NnPT1a0v3gHYR3IMd5aXXtbOo9e6cAjuXU/NQCry10Y0bNiMKkHbvnj3aGfAWlA34CRj3iOK2Nz1udDwBMdUKsgt1xiVh3h8="
-   ```
-
-1. Replace generated encrypted token with existing one
-
-1. **Tip:** deploy different builds depending on the branch:
-   ```yaml
-   script:
-     - echo "Building..."
-     - if [ "$TRAVIS_BRANCH" == "master" ]; then npm run build; else BUILD_ENV=development npm run build; fi
-   ```
-1. Push to a repository
-
-1. Enjoy
-
-[travis ci]: https://travis-ci.com/
+Enjoy


### PR DESCRIPTION
This PR introduces two Github Action workflow for the integration and the deployment of new changes on hoverboard.

I've disabled the deployment from Travis right now as we don't want to double-deploy every merge.

Fixes #982 