### PR TITLE
Revert "Bump rollup-plugin-index-html from 1.11.0 to 2.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4906,9 +4906,9 @@
       }
     },
     "@open-wc/building-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-3.0.0.tgz",
-      "integrity": "sha512-uaWtJCssP+KVH8nW01hPQnB7e1xuqlmYSbzXJia7EoUXQrIWpjIOyUNejlSfP1ii8bNjK6OhHfZ2WIuYOstmRg==",
+      "version": "2.16.3",
+      "resolved": "https://registry.npmjs.org/@open-wc/building-utils/-/building-utils-2.16.3.tgz",
+      "integrity": "sha512-lO/HD2wEl2avRSgqISeP4S1zPQEGRQ/+Zh8RBk9AggDma3uPiRU0RbuRvhunmu7hFWVDBj5o1FRJ7xJ94AWCnw==",
       "dev": true,
       "requires": {
         "@babel/core": "^7.9.0",
@@ -4952,9 +4952,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001042",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001042.tgz",
-          "integrity": "sha512-igMQ4dlqnf4tWv0xjaaE02op9AJ2oQzXKjWf4EuAHFN694Uo9/EfPVIPJcmn2WkU9RqozCxx5e2KPcVClHDbDw==",
+          "version": "1.0.30001040",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001040.tgz",
+          "integrity": "sha512-Ep0tEPeI5wCvmJNrXjE3etgfI+lkl1fTDU6Y3ZH1mhrjkPlVI9W4pcKbMo+BQLpEWKVYYp2EmYaRsqpPC3k7lQ==",
           "dev": true
         },
         "commander": {
@@ -4964,9 +4964,9 @@
           "dev": true
         },
         "electron-to-chromium": {
-          "version": "1.3.413",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.413.tgz",
-          "integrity": "sha512-Jm1Rrd3siqYHO3jftZwDljL2LYQafj3Kki5r+udqE58d0i91SkjItVJ5RwlJn9yko8i7MOcoidVKjQlgSdd1hg==",
+          "version": "1.3.403",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.403.tgz",
+          "integrity": "sha512-JaoxV4RzdBAZOnsF4dAlZ2ijJW72MbqO5lNfOBHUWiBQl3Rwe+mk2RCUMrRI3rSClLJ8HSNQNqcry12H+0ZjFw==",
           "dev": true
         },
         "node-releases": {
@@ -4982,9 +4982,9 @@
           "dev": true
         },
         "resolve": {
-          "version": "1.16.1",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz",
-          "integrity": "sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==",
+          "version": "1.15.1",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
+          "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
           "dev": true,
           "requires": {
             "path-parse": "^1.0.6"
@@ -22180,13 +22180,13 @@
       }
     },
     "rollup-plugin-index-html": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-index-html/-/rollup-plugin-index-html-2.0.0.tgz",
-      "integrity": "sha512-6nShPkqA+bN7y7KgLWyQjiz4+U5/ZV0ToRKaLhjLQbwdhWSc9kbAMcMLVjpNzKP28Hd0Cy5yEA9lLNiDA78/kg==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-index-html/-/rollup-plugin-index-html-1.11.0.tgz",
+      "integrity": "sha512-/XOjrefVf5undG/zAa+mVRJDSTFSgjFAuHmDNCOg5H4TYffBNYg55cS2mhEed/8yv91xZ1FWdL4Z7hbSe1fwdA==",
       "dev": true,
       "requires": {
         "@import-maps/resolve": "^0.2.6",
-        "@open-wc/building-utils": "^3.0.0",
+        "@open-wc/building-utils": "^2.16.3",
         "deepmerge": "^4.2.2",
         "lit-html": "^1.0.0",
         "md5": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "rimraf": "^3.0.2",
     "rollup": "^2.9.1",
     "rollup-plugin-copy": "^3.3.0",
-    "rollup-plugin-index-html": "^2.0.0",
+    "rollup-plugin-index-html": "^1.11.0",
     "rollup-plugin-re": "^1.0.7",
     "rollup-plugin-workbox": "^5.0.1",
     "stylelint": "^13.3.3",


### PR DESCRIPTION
This reverts commit 9c947f600244112e0a95941ac45975908632bc24.

https://github.com/gdg-x/hoverboard/pull/897 installed a version of `rollup-plugin-index-html` that no longer exists.