### PR TITLE
Remove container class from hero to fix rendering on large displays

### DIFF
--- a/__tests__/helpers/fixtures.ts
+++ b/__tests__/helpers/fixtures.ts
@@ -13,13 +13,17 @@ export const fixture = async <T extends import('lit-element').LitElement>(
   if (!element.shadowRoot) {
     throw new Error('ShadowDOM not rendered');
   }
-  if (!element.shadowRoot.firstElementChild?.classList.contains('container')) {
-    throw new Error('Container not rendered');
+  const { shadowRoot } = element;
+  if (shadowRoot.children.length !== 1) {
+    if (shadowRoot.children.length === 0) {
+      throw new Error('Component templates must render a child');
+    }
+    console.warn('Component templates should render a single child');
   }
 
   return {
     element,
-    shadowRoot: element.shadowRoot,
-    container: element.shadowRoot.firstElementChild as HTMLDivElement,
+    shadowRoot: shadowRoot,
+    container: shadowRoot.firstElementChild as HTMLDivElement,
   };
 };

--- a/src/components/hero-block.ts
+++ b/src/components/hero-block.ts
@@ -89,7 +89,7 @@ export class HeroBlock extends ThemedElement {
   render() {
     return html`
       <div
-        class="hero-block container"
+        class="hero-block"
         style="${styleMap({ color: this.fontColor })}"
         layout
         start


### PR DESCRIPTION
Before:

<img width="1552" alt="Screen Shot 2020-09-07 at 16 30 49" src="https://user-images.githubusercontent.com/3341/92417406-8c6a0b80-f127-11ea-9aad-4a490ef5ed8d.png">

After:

<img width="1552" alt="Screen Shot 2020-09-07 at 16 31 03" src="https://user-images.githubusercontent.com/3341/92417412-9429b000-f127-11ea-91af-098820dee754.png">
