### PR TITLE
Realign hero-block with the page content

### DIFF
--- a/src/components/hero-block.ts
+++ b/src/components/hero-block.ts
@@ -23,6 +23,7 @@ export class HeroBlock extends ThemedElement {
       css`
         :host {
           margin-top: -56px;
+          display: block;
           border-bottom: 1px solid var(--divider-color);
         }
 
@@ -49,7 +50,7 @@ export class HeroBlock extends ThemedElement {
           --lazy-image-fit: cover;
         }
 
-        .content {
+        .container {
           padding: 0;
           width: 100%;
           height: unset;
@@ -98,7 +99,7 @@ export class HeroBlock extends ThemedElement {
       >
         ${this.backgroundImage && this.image}
         <div class="hero-overlay" ?show="${!!this.backgroundImage}" fit></div>
-        <div class="content">
+        <div class="container">
           <div class="hero-content">
             <slot></slot>
           </div>


### PR DESCRIPTION
The `hero-block` text is now not aligned anymore with the page content. This PR fixes it to be aligned with the rest of the content.

### Before

![Screenshot 2020-09-18 at 00 06 55](https://user-images.githubusercontent.com/3001957/93533479-45f48800-f943-11ea-8c8b-39cdfae94d2e.png)

### After

![Screenshot 2020-09-18 at 00 08 17](https://user-images.githubusercontent.com/3001957/93533487-4ab93c00-f943-11ea-9efd-d29b61d6eda2.png)
