### PR TITLE
Switch TeamPage to use RemoteData

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,7 +1,13 @@
 /* eslint-env node */
 
 // Jest doesn't support ESModules https://github.com/facebook/jest/issues/4842
-const esModuleDependencies = ['lit-element', 'lit-html', '@material', 'pwa-helpers'].join('|');
+const esModuleDependencies = [
+  'lit-element',
+  'lit-html',
+  '@material',
+  'pwa-helpers',
+  '@abraham/remotedata',
+].join('|');
 
 module.exports = {
   globals: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,11 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@abraham/remotedata": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@abraham/remotedata/-/remotedata-0.8.0.tgz",
+      "integrity": "sha512-oUKQlrfE8x7xwKatwfjDR+a6OAgqpZ0McJAMg19uBpJ6ljYhApOzqppUFn8zpDe1hNaRXsVvSVtuFBHC+od+vQ=="
+    },
     "@babel/code-frame": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "watch": "concurrently --kill-others npm:watch:*"
   },
   "dependencies": {
+    "@abraham/remotedata": "^0.8.0",
     "@google-web-components/google-youtube": "^3.0.1",
     "@material/mwc-button": "^0.18.0",
     "@polymer/app-layout": "^3.1.0",

--- a/src/models/member.test.ts
+++ b/src/models/member.test.ts
@@ -1,11 +1,18 @@
 import data from '../../docs/default-firebase-data.json';
-import { Member } from './member';
+import { MemberData } from './member';
 import { allKeys } from './utils';
 
 describe('partner', () => {
   it('matches the shape of the default data', () => {
-    const members: Member[] = Object.values(data['team'][0]['members']);
-    const keys: Array<keyof Member> = ['name', 'order', 'photo', 'photoUrl', 'socials', 'title'];
+    const members: MemberData[] = Object.values(data['team'][0]['members']);
+    const keys: Array<keyof MemberData> = [
+      'name',
+      'order',
+      'photo',
+      'photoUrl',
+      'socials',
+      'title',
+    ];
     expect(members).toHaveLength(8);
     expect(allKeys(members)).toStrictEqual(keys);
   });

--- a/src/models/member.ts
+++ b/src/models/member.ts
@@ -1,6 +1,7 @@
 import { Social } from './social';
+import { Id } from './types';
 
-export interface Member {
+export interface MemberData {
   name: string;
   order: number;
   photo: string;
@@ -8,3 +9,5 @@ export interface Member {
   socials: Social[];
   title: string;
 }
+
+export type Member = Id & MemberData;

--- a/src/models/team.test.ts
+++ b/src/models/team.test.ts
@@ -1,6 +1,11 @@
 import data from '../../docs/default-firebase-data.json';
-import { Team } from './team';
+import { MemberData } from './member';
+import { TeamData } from './team';
 import { allKeys } from './utils';
+
+type Team = TeamData & {
+  members: MemberData[];
+};
 
 describe('partner', () => {
   it('matches the shape of the default data', () => {

--- a/src/models/team.ts
+++ b/src/models/team.ts
@@ -1,6 +1,12 @@
 import { Member } from './member';
+import { Id } from './types';
 
-export interface Team {
-  members: Member[];
+export interface TeamData {
   title: string;
 }
+
+export type TeamWithoutMembers = Id & TeamData;
+
+export type Team = TeamWithoutMembers & {
+  members: Member[];
+};

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -1,0 +1,3 @@
+export interface Id {
+  id: string;
+}

--- a/src/store/team/actions.ts
+++ b/src/store/team/actions.ts
@@ -1,45 +1,45 @@
 import { Dispatch } from 'redux';
-import { FETCH_TEAM, FETCH_TEAM_FAILURE, FETCH_TEAM_SUCCESS } from './types';
+import { Member } from '../../models/member';
+import { Team, TeamWithoutMembers } from '../../models/team';
 import { db } from '../db';
+import { mergeId } from '../utils';
+import { FETCH_TEAM, FETCH_TEAM_FAILURE, FETCH_TEAM_SUCCESS, TeamActions } from './types';
 
-const _getTeamMembers = (teamId: string) =>
-  db()
-    .collection('team')
-    .doc(teamId)
-    .collection('members')
-    .get()
-    .then((snaps) => snaps.docs.map((snap) => Object.assign({}, snap.data(), { id: snap.id })));
+const getTeamIds = async (): Promise<TeamWithoutMembers[]> => {
+  const { docs } = await db().collection('team').get();
+  return docs.map<TeamWithoutMembers>(mergeId);
+};
 
-export const fetchTeam = () => (dispatch: Dispatch) => {
+const getTeamMembers = async (team: TeamWithoutMembers): Promise<Team> => {
+  const { docs } = await db().collection('team').doc(team.id).collection('members').get();
+
+  const members = docs.map<Member>(mergeId);
+  return {
+    ...team,
+    members,
+  };
+};
+
+const getTeams = async (): Promise<Team[]> => {
+  const teamIds = await getTeamIds();
+  return Promise.all(teamIds.map(getTeamMembers));
+};
+
+export const fetchTeam = () => async (dispatch: Dispatch<TeamActions>) => {
   dispatch({
     type: FETCH_TEAM,
   });
 
-  db()
-    .collection('team')
-    .get()
-    .then((snaps) =>
-      Promise.all(
-        snaps.docs.map((snap) => Promise.all([snap.data(), snap.id, _getTeamMembers(snap.id)]))
-      )
-    )
-    .then((teams) =>
-      teams.map(([team, id, members]) => {
-        return Object.assign({}, team, { id, members });
-      })
-    )
-    .then((list) => {
-      dispatch({
-        type: FETCH_TEAM_SUCCESS,
-        payload: {
-          list,
-        },
-      });
-    })
-    .catch((error) => {
-      dispatch({
-        type: FETCH_TEAM_FAILURE,
-        payload: { error },
-      });
+  try {
+    const teams = await getTeams();
+    dispatch({
+      type: FETCH_TEAM_SUCCESS,
+      payload: teams,
     });
+  } catch (error) {
+    dispatch({
+      type: FETCH_TEAM_FAILURE,
+      payload: error,
+    });
+  }
 };

--- a/src/store/team/reducers.ts
+++ b/src/store/team/reducers.ts
@@ -1,35 +1,17 @@
-import { initialTeamState } from './state';
-import { FetchTeamActionTypes, FETCH_TEAM, FETCH_TEAM_FAILURE, FETCH_TEAM_SUCCESS } from './types';
+import { Failure, Pending, Success } from '@abraham/remotedata';
+import { initialTeamState, TeamState } from './state';
+import { FETCH_TEAM, FETCH_TEAM_FAILURE, FETCH_TEAM_SUCCESS, TeamActions } from './types';
 
-export const teamReducer = (state = initialTeamState, action: FetchTeamActionTypes) => {
+export const teamReducer = (state = initialTeamState, action: TeamActions): TeamState => {
   switch (action.type) {
     case FETCH_TEAM:
-      return {
-        ...state,
-        ...{
-          fetching: true,
-          fetchingError: null,
-          list: [],
-        },
-      };
+      return new Pending();
 
     case FETCH_TEAM_FAILURE:
-      return {
-        ...state,
-        ...{
-          fetching: false,
-          fetchingError: action.payload.error,
-        },
-      };
+      return new Failure(action.payload);
 
     case FETCH_TEAM_SUCCESS:
-      return {
-        ...state,
-        ...{
-          fetching: false,
-          list: action.payload.list,
-        },
-      };
+      return new Success(action.payload);
 
     default:
       return state;

--- a/src/store/team/state.ts
+++ b/src/store/team/state.ts
@@ -1,7 +1,5 @@
-import { TeamState } from './types';
+import { Initialized, RemoteData } from '@abraham/remotedata';
+import { Team } from '../../models/team';
 
-export const initialTeamState: TeamState = {
-  fetching: false,
-  fetchingError: null,
-  list: [],
-};
+export type TeamState = RemoteData<Error, Team[]>;
+export const initialTeamState: TeamState = new Initialized();

--- a/src/store/team/types.ts
+++ b/src/store/team/types.ts
@@ -1,15 +1,8 @@
-import { FirebaseError } from 'firebase';
 import { Team } from '../../models/team';
 
 export const FETCH_TEAM = 'FETCH_TEAM';
 export const FETCH_TEAM_FAILURE = 'FETCH_TEAM_FAILURE';
 export const FETCH_TEAM_SUCCESS = 'FETCH_TEAM_SUCCESS';
-
-export interface TeamState {
-  fetching: boolean;
-  fetchingError?: FirebaseError;
-  list: Team[];
-}
 
 interface FetchTeamAction {
   type: typeof FETCH_TEAM;
@@ -17,19 +10,12 @@ interface FetchTeamAction {
 
 interface FetchTeamFailureAction {
   type: typeof FETCH_TEAM_FAILURE;
-  payload: {
-    error: FirebaseError;
-  };
+  payload: Error;
 }
 
 interface FetchTeamSuccessAction {
   type: typeof FETCH_TEAM_SUCCESS;
-  payload: {
-    list: Team[];
-  };
+  payload: Team[];
 }
 
-export type FetchTeamActionTypes =
-  | FetchTeamAction
-  | FetchTeamFailureAction
-  | FetchTeamSuccessAction;
+export type TeamActions = FetchTeamAction | FetchTeamFailureAction | FetchTeamSuccessAction;

--- a/src/store/utils.ts
+++ b/src/store/utils.ts
@@ -1,0 +1,8 @@
+import { Id } from '../models/types';
+
+export const mergeId = <T>(snapshot: firebase.firestore.QueryDocumentSnapshot): T & Id => {
+  return {
+    ...(snapshot.data() as T),
+    ...{ id: snapshot.id },
+  };
+};


### PR DESCRIPTION
- Convert Team redux to use RemoteData pattern
- Mostly convert TeamPage to also use RemoteData pattern

Polymer templates are more constricted than LitElement so I didn't implement `fold` for choosing a view

Todo:
- [x] Fix team types so the tests pass