### PR TITLE
Support empty tag arrays

### DIFF
--- a/functions/src/schedule-generator/speakers-sessions-map.ts
+++ b/functions/src/schedule-generator/speakers-sessions-map.ts
@@ -6,7 +6,8 @@ export function sessionsSpeakersMap(sessionsRaw, speakersRaw) {
     const sessionId = Object.keys(sessionsRaw)[index];
     const currentSession = sessionsRaw[sessionId];
     const sessionSpeakers = [];
-    const mainTag = currentSession.tags ? currentSession.tags[0] : 'General';
+    const mainTag =
+      currentSession.tags && currentSession.tags.length ? currentSession.tags[0] : 'General';
 
     currentSession.speakers &&
       currentSession.speakers.forEach((speakerId) => {

--- a/functions/src/schedule-generator/speakers-sessions-schedule-map.ts
+++ b/functions/src/schedule-generator/speakers-sessions-schedule-map.ts
@@ -24,7 +24,8 @@ export function sessionsSpeakersScheduleMap(sessionsRaw, speakersRaw, scheduleRa
         for (let subSessionIndex = 0; subSessionIndex < subSessionsLen; subSessionIndex++) {
           const sessionId = timeslot.sessions[sessionIndex].items[subSessionIndex];
           const subsession = sessionsRaw[sessionId];
-          const mainTag = subsession.tags ? subsession.tags[0] : 'General';
+          const mainTag =
+            subsession.tags && subsession.tags.length ? subsession.tags[0] : 'General';
           const endTimeRaw = timeslot.sessions[sessionIndex].extend
             ? day.timeslots[timeslotsIndex + timeslot.sessions[sessionIndex].extend - 1].endTime
             : timeslot.endTime;


### PR DESCRIPTION
If a session has an empty list of tags it would try to use the first element in the array which naturally doesn't exist.