### PR TITLE
Fix images being duplicated on deployments

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -41,8 +41,8 @@ export default deepmerge(config, {
     copy({
       targets: [
         {
-          src: 'images/**',
-          dest: 'dist/images',
+          src: 'images/',
+          dest: 'dist/',
         },
         {
           src: 'manifest.json',


### PR DESCRIPTION
Seems like a misconfiguration in the rollup config is causing images to be included twice. Once a the top level `images/` folder and once in their subfolders.

Here the output of the `npm run build && tree dist/images` command:

## Before

```
dist/images
├── backgrounds
│   └── home.jpg
├── c4p.jpg
├── dfua17-announced.jpg
├── favicon.ico
├── gdg-lviv.svg
├── gdg-x.svg
├── google.svg
├── home.jpg
├── icon-144.png
├── icon-192.png
├── icon-48.png
├── icon-512.png
├── icon-72.png
├── icon-96.png
├── link-icon.svg
├── logo-monochrome.svg
├── logo.svg
├── logos
│   ├── gdg-lviv.svg
│   ├── gdg-x.svg
│   └── google.svg
├── lviv1.jpg
├── lviv2.jpg
├── lviv3.jpg
├── lviv4.jpg
├── lviv5.jpg
├── lviv6.jpg
├── lviv7.jpg
├── lviv8.jpg
├── lviv9.jpg
├── manifest
│   ├── icon-144.png
│   ├── icon-192.png
│   ├── icon-48.png
│   ├── icon-512.png
│   ├── icon-72.png
│   └── icon-96.png
├── map-marker.svg
├── organizer-logo.svg
├── posts
│   ├── c4p.jpg
│   ├── dfua17-announced.jpg
│   ├── lviv1.jpg
│   ├── lviv2.jpg
│   ├── lviv3.jpg
│   ├── lviv4.jpg
│   ├── lviv5.jpg
│   ├── lviv6.jpg
│   ├── lviv7.jpg
│   ├── lviv8.jpg
│   ├── lviv9.jpg
│   ├── summary16_1.jpg
│   ├── summary16_2.jpg
│   ├── summary16_3.jpg
│   ├── summary16_4.jpg
│   ├── summary16_5.jpg
│   ├── summary16_6.jpg
│   ├── summary16_7.jpg
│   ├── summary16_8.jpg
│   └── thankyou_2.jpg
├── social-share.jpg
├── summary16_1.jpg
├── summary16_2.jpg
├── summary16_3.jpg
├── summary16_4.jpg
├── summary16_5.jpg
├── summary16_6.jpg
├── summary16_7.jpg
├── summary16_8.jpg
├── team.jpg
└── thankyou_2.jpg
```

## After

```
dist/images
├── backgrounds
│   └── home.jpg
├── favicon.ico
├── link-icon.svg
├── logo-monochrome.svg
├── logo.svg
├── logos
│   ├── gdg-lviv.svg
│   ├── gdg-x.svg
│   └── google.svg
├── manifest
│   ├── icon-144.png
│   ├── icon-192.png
│   ├── icon-48.png
│   ├── icon-512.png
│   ├── icon-72.png
│   └── icon-96.png
├── map-marker.svg
├── organizer-logo.svg
├── posts
│   ├── c4p.jpg
│   ├── dfua17-announced.jpg
│   ├── lviv1.jpg
│   ├── lviv2.jpg
│   ├── lviv3.jpg
│   ├── lviv4.jpg
│   ├── lviv5.jpg
│   ├── lviv6.jpg
│   ├── lviv7.jpg
│   ├── lviv8.jpg
│   ├── lviv9.jpg
│   ├── summary16_1.jpg
│   ├── summary16_2.jpg
│   ├── summary16_3.jpg
│   ├── summary16_4.jpg
│   ├── summary16_5.jpg
│   ├── summary16_6.jpg
│   ├── summary16_7.jpg
│   ├── summary16_8.jpg
│   └── thankyou_2.jpg
├── social-share.jpg
└── team.jpg
```