### PR TITLE
Assign speakers data to speakers property inside generatedData object.

### DIFF
--- a/functions/src/generate-sessions-speakers-schedule.ts
+++ b/functions/src/generate-sessions-speakers-schedule.ts
@@ -78,7 +78,7 @@ async function generateAndSaveData(changedSpeaker?) {
   const scheduleEnabled = scheduleConfig.enabled === 'true';
 
   if (!Object.keys(sessions).length) {
-    generatedData = { ...speakers };
+    generatedData.speakers = { ...speakers };
   } else if (!scheduleEnabled || !Object.keys(schedule).length) {
     generatedData = sessionsSpeakersMap(sessions, speakers);
   } else {


### PR DESCRIPTION
Resolves #1732 

- [x] Assign speakers data to the speakers' property inside generatedData instead of assigning this data to the object itself.