### PR TITLE
style: tags small screen design

### DIFF
--- a/src/elements/dialogs/dialog-styles.ts
+++ b/src/elements/dialogs/dialog-styles.ts
@@ -52,7 +52,7 @@ documentContainer.innerHTML = `<dom-module id="dialog-styles">
         line-height: 1.2;
       }
 
-      .tag {
+      .tags {
         margin-top: 8px;
       }
 

--- a/src/elements/dialogs/session-details.ts
+++ b/src/elements/dialogs/session-details.ts
@@ -45,7 +45,6 @@ class SessionDetails extends ReduxMixin(mixinBehaviors([IronOverlayBehavior], Po
           display: flex;
           flex-wrap: wrap;
         }
-
       </style>
 
       <polymer-helmet

--- a/src/elements/dialogs/session-details.ts
+++ b/src/elements/dialogs/session-details.ts
@@ -71,7 +71,7 @@ class SessionDetails extends ReduxMixin(mixinBehaviors([IronOverlayBehavior], Po
               <h2 class="name">[[session.title]]</h2>
               <div class="tags" hidden$="[[!session.tags.length]]">
                 <template is="dom-repeat" items="[[session.tags]]" as="tag">
-                  <span class="tag" style$="color: [[getVariableColor(tag)]]"> [[tag]]</span>
+                  <span class="tag" style$="color: [[getVariableColor(tag)]]">[[tag]]</span>
                 </template>
               </div>
 

--- a/src/elements/dialogs/session-details.ts
+++ b/src/elements/dialogs/session-details.ts
@@ -41,6 +41,11 @@ class SessionDetails extends ReduxMixin(mixinBehaviors([IronOverlayBehavior], Po
           display: inline-block;
           vertical-align: middle;
         }
+        .tags {
+          display: flex;
+          flex-wrap: wrap;
+        }
+
       </style>
 
       <polymer-helmet
@@ -66,7 +71,7 @@ class SessionDetails extends ReduxMixin(mixinBehaviors([IronOverlayBehavior], Po
               <h2 class="name">[[session.title]]</h2>
               <div class="tags" hidden$="[[!session.tags.length]]">
                 <template is="dom-repeat" items="[[session.tags]]" as="tag">
-                  <span class="tag" style$="color: [[getVariableColor(tag)]]">[[tag]]</span>
+                  <span class="tag" style$="color: [[getVariableColor(tag)]]"> [[tag]]</span>
                 </template>
               </div>
 

--- a/src/elements/dialogs/speaker-details.ts
+++ b/src/elements/dialogs/speaker-details.ts
@@ -54,7 +54,8 @@ class SpeakerDetails extends SessionsHoC(
         }
 
         .tags {
-          margin-top: 8px;
+          display: flex;
+          flex-wrap: wrap;
         }
 
         .star-rating {

--- a/src/elements/session-element.ts
+++ b/src/elements/session-element.ts
@@ -199,7 +199,7 @@ export class SessionElement extends ReduxMixin(PolymerElement) {
                 [[session.duration.mm]] min[[_getEnding(session.duration.mm)]]
               </span>
             </div>
-            <div hidden$="[[!session.tags.length]]">
+            <div class="session-footer-tags-container" hidden$="[[!session.tags.length]]">
               <template is="dom-repeat" items="[[session.tags]]" as="tag">
                 <span class="tag" style$="color: [[getVariableColor(tag)]]">[[tag]]</span>
               </template>

--- a/src/elements/session-element.ts
+++ b/src/elements/session-element.ts
@@ -134,7 +134,7 @@ export class SessionElement extends ReduxMixin(PolymerElement) {
           font-size: 12px;
           line-height: 1;
         }
-        
+
         .tags {
           display: flex;
           flex-wrap: wrap;

--- a/src/elements/session-element.ts
+++ b/src/elements/session-element.ts
@@ -134,6 +134,11 @@ export class SessionElement extends ReduxMixin(PolymerElement) {
           font-size: 12px;
           line-height: 1;
         }
+        
+        .tags {
+          display: flex;
+          flex-wrap: wrap;
+        }
 
         @media (min-width: 640px) {
           :host {
@@ -199,7 +204,7 @@ export class SessionElement extends ReduxMixin(PolymerElement) {
                 [[session.duration.mm]] min[[_getEnding(session.duration.mm)]]
               </span>
             </div>
-            <div class="session-footer-tags-container" hidden$="[[!session.tags.length]]">
+            <div class="tags" hidden$="[[!session.tags.length]]">
               <template is="dom-repeat" items="[[session.tags]]" as="tag">
                 <span class="tag" style$="color: [[getVariableColor(tag)]]">[[tag]]</span>
               </template>

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -225,8 +225,13 @@ export const theme = css`
     background: white;
     border: 1px solid currentColor;
     border-radius: 32px;
+    margin:1px;
+    line-height: initial;
   }
-
+  .session-footer-tags-container{
+    display: flex;
+    flex-wrap: wrap;
+  }
   @media (min-width: 640px) {
     .container,
     .container-narrow {

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -225,7 +225,7 @@ export const theme = css`
     background: white;
     border: 1px solid currentColor;
     border-radius: 32px;
-    margin:1px;
+    margin: 1px;
     line-height: initial;
   }
 

--- a/src/styles/theme.ts
+++ b/src/styles/theme.ts
@@ -228,10 +228,7 @@ export const theme = css`
     margin:1px;
     line-height: initial;
   }
-  .session-footer-tags-container{
-    display: flex;
-    flex-wrap: wrap;
-  }
+
   @media (min-width: 640px) {
     .container,
     .container-narrow {


### PR DESCRIPTION
This Fixes #1411 by wrapping the tags in the flex and using `flex-wrap: wrap`. There was the same issue when clicking on speaker or session.

###Screenshots
![Screenshot from 2021-11-11 23-25-06](https://user-images.githubusercontent.com/11087313/141350929-6da7618c-23e6-4b3e-9f0c-b50e0019e1b1.png)
![Screenshot from 2021-11-11 23-43-23](https://user-images.githubusercontent.com/11087313/141350937-75fb5508-7439-4597-9bdf-cbe7721fe642.png)
![Screenshot from 2021-11-11 23-54-04](https://user-images.githubusercontent.com/11087313/141350952-8b027be1-b196-452b-877d-cbf2005e6bd3.png)

