### PR TITLE
Markdown: fix TOC not centered

### DIFF
--- a/src/components/markdown/toc-markdown.ts
+++ b/src/components/markdown/toc-markdown.ts
@@ -135,7 +135,7 @@ export class TocMarkdown extends Markdown {
   private get renderToc() {
     return html`
       <div class="content-wrapper">
-        <div class="container"></div>
+        <div class="container">
           <div class="content" layout justified horizontal wrap>
             ${Object.keys(this.headerIds).map((headerId) =>
               this.renderHeader(headerId, this.headerIds[headerId]!)


### PR DESCRIPTION
The TOC in markdown was not within a container