### PR TITLE
Fix Notifications permission on Firefox private browsing

### DIFF
--- a/src/store/notification-permission/index.ts
+++ b/src/store/notification-permission/index.ts
@@ -8,8 +8,6 @@ export enum PROMPT_USER {
   NO = 'NO',
 }
 
-const messaging = getMessaging(firebaseApp);
-
 // Eslint doesn't like when using the built in type
 export type NotificationPermission = typeof Notification.permission;
 
@@ -27,8 +25,12 @@ export const requestNotificationPermission = createAsyncThunk<string | undefined
         : Notification.permission;
 
     if (permission === 'granted') {
-      const token = await getToken(messaging);
-      return token;
+      try {
+        const messaging = getMessaging(firebaseApp);
+        return await getToken(messaging);
+      } catch (error) {
+        return undefined;
+      }
     } else if (permission === 'default') {
       return undefined;
     } else {

--- a/src/store/notification-permission/index.ts
+++ b/src/store/notification-permission/index.ts
@@ -29,7 +29,7 @@ export const requestNotificationPermission = createAsyncThunk<string | undefined
         const messaging = getMessaging(firebaseApp);
         return await getToken(messaging);
       } catch (error) {
-        return undefined;
+        throw new Error('unsupported');
       }
     } else if (permission === 'default') {
       return undefined;


### PR DESCRIPTION
Close #2552 


Tested in production on https://sunny-tech.io and notification still reach Firefox in normal mode 