### PR TITLE
Functions: Fix general notifications path replacing the whole payload

### DIFF
--- a/functions/src/notifications.ts
+++ b/functions/src/notifications.ts
@@ -52,7 +52,7 @@ export const sendGeneralNotification = functions.firestore
     };
 
     if (message.path) {
-      payload.data = message.path;
+      payload.data.path = message.path;
     }
 
     const tokensToRemove = [];


### PR DESCRIPTION
The general notification when supplied with a `path` was replacing the whole payload resulting in a failure to deliver the notification. 

It only need to update the `payload.data.path`. 
I've tested it in production without any issue 